### PR TITLE
fix: account ID negotiation for multi-account OAuth users

### DIFF
--- a/src/auth/api-token-mode.ts
+++ b/src/auth/api-token-mode.ts
@@ -35,7 +35,7 @@ export function extractBearerToken(request: Request): string | null {
  */
 export async function handleApiTokenRequest(
   request: Request,
-  createMcpResponse: (token: string, accountId?: string) => Promise<Response>
+  createMcpResponse: (token: string, accountId?: string, props?: AuthProps) => Promise<Response>
 ): Promise<Response | null> {
   if (!isDirectApiToken(request)) {
     return null
@@ -68,11 +68,13 @@ export async function handleApiTokenRequest(
           { status: 400, headers: { 'Content-Type': 'application/json' } }
         )
       }
-      return createMcpResponse(token, accounts[0].id)
+      const props = buildAuthProps(token, null, accounts)
+      return createMcpResponse(token, accounts[0].id, props)
     }
 
     // User token
-    return createMcpResponse(token)
+    const props = buildAuthProps(token, user, accounts)
+    return createMcpResponse(token, undefined, props)
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Token verification failed'
     return new Response(JSON.stringify({ error: message }), {

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,9 +18,10 @@ async function createMcpResponse(
   env: Env,
   ctx: ExecutionContext,
   token: string,
-  accountId?: string
+  accountId?: string,
+  props?: AuthProps
 ): Promise<Response> {
-  const server = createServer(env, token, accountId)
+  const server = createServer(env, token, accountId, props)
   const transport = new WebStandardStreamableHTTPServerTransport({
     sessionIdGenerator: undefined,
     enableJsonResponse: true,
@@ -51,7 +52,7 @@ function createMcpHandler() {
       })
     }
     const accountId = props.type === 'account_token' ? props.account.id : undefined
-    return createMcpResponse(c.req.raw, c.env, ctx, props.accessToken, accountId)
+    return createMcpResponse(c.req.raw, c.env, ctx, props.accessToken, accountId, props)
   })
 
   return app
@@ -61,8 +62,8 @@ export default {
   async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
     // Check for direct API token first (like GitHub MCP's PAT support)
     if (isDirectApiToken(request)) {
-      const response = await handleApiTokenRequest(request, (token, accountId) =>
-        createMcpResponse(request, env, ctx, token, accountId)
+      const response = await handleApiTokenRequest(request, (token, accountId, props) =>
+        createMcpResponse(request, env, ctx, token, accountId, props)
       )
       if (response) return response
     }


### PR DESCRIPTION
## Summary
- When a user token (OAuth) is used and no `account_id` is provided, the execute tool now returns an error listing all available accounts so the user can pick one
- Account tokens continue to work as before with no `account_id` parameter needed
- Passes `AuthProps` through from the OAuth layer to the MCP server so it has access to the user's account list

## Test plan
- [x] Deployed to staging and tested with OAuth authentication
- [x] Verified: calling execute without `account_id` returns error with list of available accounts
- [x] Verified: calling execute with valid `account_id` works correctly
- [ ] Verify account token mode still works without `account_id` parameter

Closes #3