### PR TITLE
feat: improve scope templates and remove dead code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2271,6 +2271,7 @@
       "integrity": "sha512-NNu0sjyNxpoiW3YuVFfNz7mxSQ+S4X2G28uqg2s+CzoqoQjLPsWSbsFFyztIAqt2vb8kfEAsJNepMGPTxFDx3Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2338,6 +2339,7 @@
       "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "3.2.4",
         "pathe": "^2.0.3",
@@ -2353,6 +2355,7 @@
       "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/pretty-format": "3.2.4",
         "magic-string": "^0.30.17",
@@ -2851,6 +2854,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -3098,6 +3102,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.9.tgz",
       "integrity": "sha512-Eaw2YTGM6WOxA6CXbckaEvslr2Ne4NFsKrvc0v97JD5awbmeBLO5w9Ho9L9kmKonrwF9RJlW6BxT1PVv/agBHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -3532,6 +3537,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4067,6 +4073,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -4132,6 +4139,7 @@
       "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pathe": "^2.0.3"
       }
@@ -4259,6 +4267,7 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -4365,6 +4374,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "workerd": "bin/workerd"
       },
@@ -4493,6 +4503,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.5.tgz",
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/auth/scopes.ts
+++ b/src/auth/scopes.ts
@@ -129,23 +129,6 @@ export type ScopeName = keyof typeof ALL_SCOPES
 /** Scopes required for basic functionality - always included */
 export const REQUIRED_SCOPES: ScopeName[] = ['user:read', 'offline_access', 'account:read']
 
-/** All read-only scopes (ending in :read) */
-export const READ_ONLY_SCOPES: ScopeName[] = (Object.keys(ALL_SCOPES) as ScopeName[]).filter(
-  (scope) => scope.endsWith(':read')
-)
-
-/** All write/edit scopes */
-export const WRITE_SCOPES: ScopeName[] = (Object.keys(ALL_SCOPES) as ScopeName[]).filter(
-  (scope) =>
-    scope.endsWith(':write') ||
-    scope.endsWith(':edit') ||
-    scope.endsWith(':run') ||
-    scope.endsWith(':setup') ||
-    scope.endsWith(':admin') ||
-    scope.endsWith(':bind') ||
-    scope.endsWith(':pii')
-)
-
 /** Scope templates for quick selection */
 export const SCOPE_TEMPLATES = {
   'read-only': {
@@ -153,18 +136,16 @@ export const SCOPE_TEMPLATES = {
     description: 'View resources without making changes. Safest option for exploration.',
     scopes: [
       ...REQUIRED_SCOPES,
-      'zone:read',
-      'workers:read',
-      'workers_tail:read',
-      'pages:read'
+      ...(Object.keys(ALL_SCOPES) as ScopeName[]).filter(
+        (scope) => scope.endsWith(':read') && !REQUIRED_SCOPES.includes(scope)
+      )
     ] as ScopeName[]
   },
   'workers-full': {
     name: 'Workers Full Access',
-    description: 'Full access to Workers, KV, D1, R2, and related services.',
+    description: 'Full access to Workers, KV, D1, R2, and related services with observability.',
     scopes: [
       ...REQUIRED_SCOPES,
-      'account:read',
       'workers:read',
       'workers:write',
       'workers_scripts:write',
@@ -173,6 +154,11 @@ export const SCOPE_TEMPLATES = {
       'workers_tail:read',
       'workers_builds:read',
       'workers_builds:write',
+      'workers_observability:read',
+      'workers_observability:write',
+      'workers_observability_telemetry:write',
+      'logpush:read',
+      'logpush:write',
       'd1:write',
       'r2_catalog:write',
       'queues:write',
@@ -185,12 +171,33 @@ export const SCOPE_TEMPLATES = {
     description: 'Full access to DNS records and zone settings.',
     scopes: [
       ...REQUIRED_SCOPES,
-      'account:read',
       'zone:read',
       'dns_records:read',
       'dns_records:edit',
       'dns_settings:read',
       'dns_analytics:read'
+    ] as ScopeName[]
+  },
+  'security-full': {
+    name: 'Security Full Access',
+    description: 'Full access to Zero Trust, Access, SSO, and connectivity.',
+    scopes: [
+      ...REQUIRED_SCOPES,
+      'access:read',
+      'access:write',
+      'teams:read',
+      'teams:write',
+      'teams:pii',
+      'teams:secure_location',
+      'sso-connector:read',
+      'sso-connector:write',
+      'connectivity:admin',
+      'connectivity:bind',
+      'connectivity:read',
+      'cfone:read',
+      'cfone:write',
+      'dex:read',
+      'dex:write'
     ] as ScopeName[]
   },
   'full-access': {


### PR DESCRIPTION
## Summary
- Remove unused `READ_ONLY_SCOPES` and `WRITE_SCOPES` exports (dead code, never imported anywhere)
- Make the `read-only` template programmatically include all `:read` scopes from `ALL_SCOPES`, so new read scopes are automatically picked up
- Add observability scopes (`workers_observability`, `logpush`) to the `workers-full` template
- Add new `security-full` template covering Zero Trust, Access, SSO, connectivity, Cloudflare One, and DEX
- Remove duplicate `account:read` entries from `workers-full` and `dns-full` templates (already in `REQUIRED_SCOPES`)

## Test plan
- [x] All 34 existing tests pass (`npm test`)
- [x] Read-only template validation test confirms no write scopes leak in
- [x] All template scopes validated against `ALL_SCOPES` and `REGISTERED_SCOPES`