### PR TITLE
fix: use checkbox state as source of truth for OAuth scopes

### DIFF
--- a/src/auth/oauth-handler.ts
+++ b/src/auth/oauth-handler.ts
@@ -249,7 +249,9 @@ export function createAuthHandlers() {
       const oauthReqInfo = state.oauthReqInfo as AuthRequest
 
       // Checkboxes are the source of truth — accept whatever the frontend sends
-      const scopesToRequest = (selectedScopes && selectedScopes.length > 0 ? selectedScopes : []).slice(0, MAX_SCOPES)
+      const scopesToRequest = (
+        selectedScopes && selectedScopes.length > 0 ? selectedScopes : []
+      ).slice(0, MAX_SCOPES)
 
       // Update oauthReqInfo with selected scopes
       oauthReqInfo.scope = scopesToRequest


### PR DESCRIPTION
## Summary
- The backend treated template selection and individual scope checkboxes as mutually exclusive (if/else), so selecting a template then ticking extra scopes in the advanced section would silently drop the template scopes
- Now the backend simply accepts whatever checkboxes the frontend sends — templates only preset checkboxes in the UI, the final checkbox state is the source of truth
- Removes the silent default fallback: if no scopes are selected, an empty array is sent and Cloudflare's OAuth server handles validation

## Test plan
- [ ] Select "workers full" template, submit — should get all workers scopes
- [ ] Select "workers full" template, expand advanced, tick "access write", submit — should get workers scopes + access write
- [ ] Select "workers full" template, expand advanced, untick a scope, submit — should get workers scopes minus the unticked one
- [ ] Submit with no scopes selected — should be rejected by Cloudflare OAuth server