### PR TITLE
fix: make hero 3D scene and header mobile-friendly

### DIFF
--- a/site/src/components/Header.tsx
+++ b/site/src/components/Header.tsx
@@ -3,7 +3,7 @@ import { ThemeToggle } from './ThemeToggle'
 export function Header() {
   return (
     <header className="sticky top-0 z-50 bg-(--color-surface-secondary) border-b border-(--color-border)">
-      <div className="mx-auto flex h-12 max-w-[var(--max-width)] items-center border-x border-dashed border-(--color-border) px-6">
+      <div className="mx-auto flex h-12 max-w-[var(--max-width)] items-center border-x border-dashed border-(--color-border) px-3 sm:px-6">
         <div className="flex items-center gap-3">
           <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -29,7 +29,7 @@ export function Header() {
           <h1 className="text-base font-medium">MCP</h1>
         </div>
         <div className="ml-auto flex items-center gap-3">
-          <p className="font-mono text-xs text-(--color-muted)">mcp.cloudflare.com</p>
+          <p className="hidden font-mono text-xs text-(--color-muted) sm:block">mcp.cloudflare.com</p>
           <ThemeToggle />
         </div>
       </div>

--- a/site/src/components/Hero/GridSquares.tsx
+++ b/site/src/components/Hero/GridSquares.tsx
@@ -223,7 +223,8 @@ export function GridSquares({
     if (canvasWidth === 0 || canvasHeight === 0) return
 
     const initialCards: ActiveCard[] = []
-    const targetCount = 6
+    // Fewer cards on small screens to avoid crowding
+    const targetCount = canvasWidth < 640 ? 3 : 6
 
     for (let i = 0; i < targetCount; i++) {
       const card = generateRandomCard(initialCards)
@@ -254,7 +255,8 @@ export function GridSquares({
         }
 
         // Occasionally add an extra card if below target
-        if (newCards.length < 3) {
+        const minCards = canvasWidth < 640 ? 2 : 3
+        if (newCards.length < minCards) {
           const extraCard = generateRandomCard(newCards)
           if (extraCard) {
             newCards.push(extraCard)


### PR DESCRIPTION
## Summary
- Adds a `ResponsiveCamera` component that pulls the Three.js camera back on narrow viewports so the "MODEL CONTEXT PROTOCOL" 3D text fits without clipping
- Adds touch event support (`touchmove`/`touchend`) for the interactive trail/x-ray effect and icon desaturation, so the hero is interactive on mobile
- Reduces icon card count from 6 to 3 on small screens (`< 640px`) to avoid crowding
- Hides "mcp.cloudflare.com" text and tightens header padding on mobile

## Test plan
- [ ] Open on a mobile device or use Chrome DevTools device emulation
- [ ] Verify 3D text is fully visible and not clipped on narrow screens
- [ ] Verify touch interactions trigger the trail/x-ray effect
- [ ] Verify icon cards don't crowd the scene on mobile
- [ ] Verify header looks good on small screens