### PR TITLE
fix: move API token injection to GlobalOutbound via props

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -65,6 +65,7 @@ declare const spec: {
 
 export async function createServer(
   env: Env,
+  ctx: ExecutionContext,
   apiToken: string,
   accountId: string | undefined,
   props?: AuthProps
@@ -74,7 +75,7 @@ export async function createServer(
     version: '0.1.0'
   })
 
-  const executeCode = createCodeExecutor(env)
+  const executeCode = createCodeExecutor(env, ctx)
   const executeSearch = createSearchExecutor(env)
 
   const obj = await env.SPEC_BUCKET.get('products.json')


### PR DESCRIPTION
## Summary

- Moves API token injection from the dynamic worker isolate to `GlobalOutbound` via the `props` mechanism
- `GlobalOutbound` now accepts `{ apiToken: string }` props and injects the `Authorization` header on allowed outbound requests
- The dynamic worker code no longer receives or references the API token — `typeof apiToken` is `undefined` inside user code
- Prevents token theft via `globalThis.fetch` proxy attacks since the token is added outside the user code isolate

## Test plan

- [x] `typeof apiToken` returns `undefined` in user code
- [x] `cloudflare.request()` still works (REST + GraphQL)
- [x] Fetch proxy attack (`globalThis.fetch = ...`) returns `null` for captured Authorization header
- [x] Outbound fetch to non-CF domains still blocked
- [x] All 69 unit tests pass
- [x] `npm run format` clean
- [x] Deployed and verified on staging