### PR TITLE
feat: support Cloudflare Global API Key authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,34 @@ For CI/CD, automation, or if you prefer managing tokens yourself.
 
 Create a [Cloudflare API token](https://dash.cloudflare.com/profile/api-tokens) with the permissions you need. Both **user tokens** and **account tokens** are supported. For account tokens, include the **Account Resources : Read** permission so the server can auto-detect your account ID.
 
-### Add to Agent
+#### Add to Agent
 
 | Setting      | Value                                                                       |
 | ------------ | --------------------------------------------------------------------------- |
 | MCP URL      | `https://mcp.cloudflare.com/mcp`                                            |
 | Bearer Token | Your [Cloudflare API Token](https://dash.cloudflare.com/profile/api-tokens) |
+
+### Option 3: Global API Key
+
+> **Warning:** The Global API Key grants **full access** to your Cloudflare account — equivalent to your dashboard login. Prefer [API Tokens](#option-2-api-token) with scoped permissions when possible.
+
+If you need to use your [Global API Key](https://dash.cloudflare.com/profile/api-tokens), pass it via `X-Auth-Email` and `X-Auth-Key` headers instead of a Bearer token.
+
+#### Example JSON Configuration
+
+```json
+{
+  "mcpServers": {
+    "cloudflare-api": {
+      "url": "https://mcp.cloudflare.com/mcp",
+      "headers": {
+        "X-Auth-Email": "you@example.com",
+        "X-Auth-Key": "your-global-api-key"
+      }
+    }
+  }
+}
+```
 
 ## The Problem
 

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -26,7 +26,19 @@ export const UserAuthProps = z.object({
   refreshToken: z.string().optional()
 })
 
-export const AuthProps = z.discriminatedUnion('type', [AccountAuthProps, UserAuthProps])
+export const GlobalApiKeyAuthProps = z.object({
+  type: z.literal('global_api_key'),
+  email: z.string(),
+  apiKey: z.string(),
+  user: UserSchema,
+  accounts: AccountsSchema
+})
+
+export const AuthProps = z.discriminatedUnion('type', [
+  AccountAuthProps,
+  UserAuthProps,
+  GlobalApiKeyAuthProps
+])
 
 export type AuthProps = z.infer<typeof AuthProps>
 export type UserSchema = z.infer<typeof UserSchema>

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -1,3 +1,7 @@
+export type OutboundAuth =
+  | { type: 'bearer'; apiToken: string }
+  | { type: 'global_api_key'; email: string; apiKey: string }
+
 interface CodeExecutorEntrypoint {
   evaluate(): Promise<{ result: unknown; err?: string; stack?: string }>
 }
@@ -9,12 +13,12 @@ interface SearchExecutorEntrypoint {
 export function createCodeExecutor(env: Env, ctx: ExecutionContext) {
   const apiBase = env.CLOUDFLARE_API_BASE
 
-  return async (code: string, accountId: string, apiToken: string): Promise<unknown> => {
+  return async (code: string, accountId: string, outboundAuth: OutboundAuth): Promise<unknown> => {
     const workerId = `cloudflare-api-${crypto.randomUUID()}`
 
     const worker = env.LOADER.get(workerId, () => ({
       compatibilityDate: '2026-01-12',
-      globalOutbound: ctx.exports.GlobalOutbound({ props: { apiToken } }),
+      globalOutbound: ctx.exports.GlobalOutbound({ props: outboundAuth }),
       mainModule: 'worker.js',
       modules: {
         'worker.js': `

--- a/src/tests/auth/api-token-mode.test.ts
+++ b/src/tests/auth/api-token-mode.test.ts
@@ -5,6 +5,7 @@ import {
   buildAuthProps,
   isGlobalApiKey
 } from '../../auth/api-token-mode'
+import { buildCloudflareAuthHeaders } from '../../auth/oauth-handler'
 
 /**
  * Helper to create a mock Request with given headers
@@ -173,5 +174,26 @@ describe('isGlobalApiKey', () => {
       'X-Auth-Key': 'global-api-key-123'
     })
     expect(isGlobalApiKey(request)).toBe(true)
+  })
+})
+
+describe('buildCloudflareAuthHeaders', () => {
+  it('should return Bearer header for bearer auth', () => {
+    const headers = buildCloudflareAuthHeaders({ type: 'bearer', token: 'my-token' })
+
+    expect(headers).toEqual({ Authorization: 'Bearer my-token' })
+  })
+
+  it('should return X-Auth-Email and X-Auth-Key for global_api_key auth', () => {
+    const headers = buildCloudflareAuthHeaders({
+      type: 'global_api_key',
+      email: 'user@example.com',
+      apiKey: 'key-123'
+    })
+
+    expect(headers).toEqual({
+      'X-Auth-Email': 'user@example.com',
+      'X-Auth-Key': 'key-123'
+    })
   })
 })

--- a/src/tests/executor.test.ts
+++ b/src/tests/executor.test.ts
@@ -53,7 +53,7 @@ describe('GraphQL Support', () => {
         }
       `
 
-      await executor(code, 'test-account', 'test-token')
+      await executor(code, 'test-account', { type: 'bearer', apiToken: 'test-token' })
 
       // Verify the LOADER.get was called with correct worker code
       const loaderCall = mockEnv.LOADER.get as any
@@ -67,7 +67,10 @@ describe('GraphQL Support', () => {
       // We're testing that the code generation includes the GraphQL handling
       const loaderCall = mockEnv.LOADER.get as any
 
-      await executor('async () => { return {} }', 'test-account', 'test-token')
+      await executor('async () => { return {} }', 'test-account', {
+        type: 'bearer',
+        apiToken: 'test-token'
+      })
 
       const workerConfig = loaderCall.mock.calls[0][1]()
       const workerCode = workerConfig.modules['worker.js']
@@ -80,7 +83,10 @@ describe('GraphQL Support', () => {
 
     it('should handle GraphQL path with query parameters', async () => {
       const executor = createCodeExecutor(mockEnv, mockCtx)
-      await executor('async () => { return {} }', 'test-account', 'test-token')
+      await executor('async () => { return {} }', 'test-account', {
+        type: 'bearer',
+        apiToken: 'test-token'
+      })
 
       const loaderCall = mockEnv.LOADER.get as any
       const workerConfig = loaderCall.mock.calls[0][1]()
@@ -93,7 +99,10 @@ describe('GraphQL Support', () => {
 
     it('should not treat non-GraphQL paths as GraphQL', async () => {
       const executor = createCodeExecutor(mockEnv, mockCtx)
-      await executor('async () => { return {} }', 'test-account', 'test-token')
+      await executor('async () => { return {} }', 'test-account', {
+        type: 'bearer',
+        apiToken: 'test-token'
+      })
 
       const loaderCall = mockEnv.LOADER.get as any
       const workerConfig = loaderCall.mock.calls[0][1]()
@@ -108,7 +117,10 @@ describe('GraphQL Support', () => {
   describe('Response Handling', () => {
     it('should include partial response handling logic', async () => {
       const executor = createCodeExecutor(mockEnv, mockCtx)
-      await executor('async () => { return {} }', 'test-account', 'test-token')
+      await executor('async () => { return {} }', 'test-account', {
+        type: 'bearer',
+        apiToken: 'test-token'
+      })
 
       const loaderCall = mockEnv.LOADER.get as any
       const workerConfig = loaderCall.mock.calls[0][1]()
@@ -123,7 +135,10 @@ describe('GraphQL Support', () => {
 
     it('should include error path in error messages', async () => {
       const executor = createCodeExecutor(mockEnv, mockCtx)
-      await executor('async () => { return {} }', 'test-account', 'test-token')
+      await executor('async () => { return {} }', 'test-account', {
+        type: 'bearer',
+        apiToken: 'test-token'
+      })
 
       const loaderCall = mockEnv.LOADER.get as any
       const workerConfig = loaderCall.mock.calls[0][1]()
@@ -136,7 +151,10 @@ describe('GraphQL Support', () => {
 
     it('should handle errors array robustly', async () => {
       const executor = createCodeExecutor(mockEnv, mockCtx)
-      await executor('async () => { return {} }', 'test-account', 'test-token')
+      await executor('async () => { return {} }', 'test-account', {
+        type: 'bearer',
+        apiToken: 'test-token'
+      })
 
       const loaderCall = mockEnv.LOADER.get as any
       const workerConfig = loaderCall.mock.calls[0][1]()
@@ -148,7 +166,10 @@ describe('GraphQL Support', () => {
 
     it('should normalize GraphQL response format', async () => {
       const executor = createCodeExecutor(mockEnv, mockCtx)
-      await executor('async () => { return {} }', 'test-account', 'test-token')
+      await executor('async () => { return {} }', 'test-account', {
+        type: 'bearer',
+        apiToken: 'test-token'
+      })
 
       const loaderCall = mockEnv.LOADER.get as any
       const workerConfig = loaderCall.mock.calls[0][1]()
@@ -164,7 +185,10 @@ describe('GraphQL Support', () => {
   describe('Error Scenarios', () => {
     it('should include logic for complete failure (no data, only errors)', async () => {
       const executor = createCodeExecutor(mockEnv, mockCtx)
-      await executor('async () => { return {} }', 'test-account', 'test-token')
+      await executor('async () => { return {} }', 'test-account', {
+        type: 'bearer',
+        apiToken: 'test-token'
+      })
 
       const loaderCall = mockEnv.LOADER.get as any
       const workerConfig = loaderCall.mock.calls[0][1]()
@@ -177,7 +201,10 @@ describe('GraphQL Support', () => {
 
     it('should extract error codes from extensions', async () => {
       const executor = createCodeExecutor(mockEnv, mockCtx)
-      await executor('async () => { return {} }', 'test-account', 'test-token')
+      await executor('async () => { return {} }', 'test-account', {
+        type: 'bearer',
+        apiToken: 'test-token'
+      })
 
       const loaderCall = mockEnv.LOADER.get as any
       const workerConfig = loaderCall.mock.calls[0][1]()
@@ -191,7 +218,10 @@ describe('GraphQL Support', () => {
   describe('REST API Compatibility', () => {
     it('should preserve REST API handling', async () => {
       const executor = createCodeExecutor(mockEnv, mockCtx)
-      await executor('async () => { return {} }', 'test-account', 'test-token')
+      await executor('async () => { return {} }', 'test-account', {
+        type: 'bearer',
+        apiToken: 'test-token'
+      })
 
       const loaderCall = mockEnv.LOADER.get as any
       const workerConfig = loaderCall.mock.calls[0][1]()
@@ -206,7 +236,10 @@ describe('GraphQL Support', () => {
 
     it('should preserve non-JSON response handling', async () => {
       const executor = createCodeExecutor(mockEnv, mockCtx)
-      await executor('async () => { return {} }', 'test-account', 'test-token')
+      await executor('async () => { return {} }', 'test-account', {
+        type: 'bearer',
+        apiToken: 'test-token'
+      })
 
       const loaderCall = mockEnv.LOADER.get as any
       const workerConfig = loaderCall.mock.calls[0][1]()
@@ -221,7 +254,10 @@ describe('GraphQL Support', () => {
   describe('Worker Code Generation', () => {
     it('should inject cloudflare.request function', async () => {
       const executor = createCodeExecutor(mockEnv, mockCtx)
-      await executor('async () => { return {} }', 'test-account', 'test-token')
+      await executor('async () => { return {} }', 'test-account', {
+        type: 'bearer',
+        apiToken: 'test-token'
+      })
 
       const loaderCall = mockEnv.LOADER.get as any
       const workerConfig = loaderCall.mock.calls[0][1]()
@@ -233,7 +269,10 @@ describe('GraphQL Support', () => {
 
     it('should use correct compatibility date', async () => {
       const executor = createCodeExecutor(mockEnv, mockCtx)
-      await executor('async () => { return {} }', 'test-account', 'test-token')
+      await executor('async () => { return {} }', 'test-account', {
+        type: 'bearer',
+        apiToken: 'test-token'
+      })
 
       const loaderCall = mockEnv.LOADER.get as any
       const workerConfig = loaderCall.mock.calls[0][1]()


### PR DESCRIPTION
## Summary

- Adds support for authenticating with Cloudflare's [Global API Key](https://developers.cloudflare.com/fundamentals/api/get-started/keys/#view-your-global-api-key) via `X-Auth-Email` + `X-Auth-Key` headers, alongside the existing OAuth and Bearer token methods
- Global API Key credentials flow through `GlobalOutbound` props — same isolation pattern as Bearer tokens (#28), never entering the dynamic worker isolate
- `getUserAndAccounts` is generalized to accept either auth style (backward-compatible, still accepts a plain string)
- `OutboundAuth` discriminated union replaces the raw `apiToken: string` plumbing through the executor and server, so `GlobalOutbound` injects the correct headers (`Authorization: Bearer` vs `X-Auth-Email`/`X-Auth-Key`)
- README updated with Option 3 documenting the Global API Key config, with a warning that it grants full account access

### Files changed

| File | Change |
|------|--------|
| `src/auth/types.ts` | Add `global_api_key` variant to `AuthProps` union |
| `src/auth/oauth-handler.ts` | Add `buildCloudflareAuthHeaders`, generalize `getUserAndAccounts` |
| `src/auth/api-token-mode.ts` | Add `isGlobalApiKey` detection + `handleGlobalApiKeyRequest` handler |
| `src/index.ts` | Update `GlobalOutbound` props to support both auth types, wire up Global API Key check |
| `src/executor.ts` | Replace `apiToken: string` with `OutboundAuth` union |
| `src/server.ts` | Add `getOutboundAuth` helper, pass `OutboundAuth` to executor |
| `README.md` | Add Option 3: Global API Key section |

## Test plan

- [x] `isGlobalApiKey` correctly detects `X-Auth-Email` + `X-Auth-Key` headers (5 test cases)
- [x] `buildCloudflareAuthHeaders` returns correct headers for both auth types (2 test cases)
- [x] Existing `isDirectApiToken`, `extractBearerToken`, `buildAuthProps` tests still pass (unchanged)
- [x] Executor tests updated to use `OutboundAuth` type instead of raw string
- [x] Tested locally with `wrangler dev` — Global API Key request successfully authenticates, `tools/list` returns both tools, `execute` tool runs code against the Cloudflare API
- [x] Bearer token and OAuth paths unaffected (no breaking changes)
- [x] All 76 tests pass, `npm run check` clean (format, lint, typecheck, test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)