### PR TITLE
docs: add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,134 @@
+name: Bug Report
+description: Report a bug with the Cloudflare MCP server
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. Please fill out the sections below so we can reproduce and fix the issue.
+
+  - type: dropdown
+    id: mcp-client
+    attributes:
+      label: MCP Client
+      description: Which MCP client are you using?
+      options:
+        - Claude Desktop
+        - Claude Code (CLI)
+        - Cursor
+        - Windsurf
+        - VS Code (Copilot)
+        - Other (please specify below)
+    validations:
+      required: true
+
+  - type: input
+    id: mcp-client-version
+    attributes:
+      label: MCP Client Version
+      description: Version of your MCP client (e.g. Claude Desktop 1.2.3)
+      placeholder: e.g. Claude Desktop 1.2.3
+    validations:
+      required: false
+
+  - type: dropdown
+    id: auth-type
+    attributes:
+      label: Authentication Type
+      description: How are you authenticating with Cloudflare?
+      options:
+        - OAuth
+        - User API Token
+        - Account API Token
+    validations:
+      required: true
+
+  - type: textarea
+    id: oauth-scopes
+    attributes:
+      label: OAuth Scopes (if applicable)
+      description: If using OAuth, which scopes did you select?
+      placeholder: e.g. account:read, workers:write
+    validations:
+      required: false
+
+  - type: textarea
+    id: config
+    attributes:
+      label: MCP Server Configuration
+      description: Paste your MCP server config (redact any tokens or secrets).
+      render: json
+      placeholder: |
+        {
+          "mcpServers": {
+            "cloudflare": {
+              "command": "...",
+              "args": ["..."]
+            }
+          }
+        }
+    validations:
+      required: true
+
+  - type: input
+    id: endpoint
+    attributes:
+      label: Failing Endpoint / Tool
+      description: Which API endpoint or MCP tool was being called when the error occurred?
+      placeholder: e.g. workers_list, kv_get, or /accounts/{id}/workers/scripts
+    validations:
+      required: false
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug Description
+      description: A clear description of the bug.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: Step-by-step instructions to reproduce the issue.
+      placeholder: |
+        1. Configure MCP server with ...
+        2. Authenticate using ...
+        3. Call tool / make request ...
+        4. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened? Include any error messages.
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant Logs / Error Output
+      description: Paste any relevant logs or error output. Redact sensitive information.
+      render: shell
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Any other context, screenshots, or information that might help.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Cloudflare MCP Documentation
+    url: https://developers.cloudflare.com/agents/model-context-protocol/
+    about: Check the official documentation before opening an issue

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,40 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement! Please describe what you'd like to see.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem does this feature solve? Is this related to a frustration with the current behavior?
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe the solution you'd like.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Any alternative solutions or features you've considered.
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Any other context, screenshots, or references.
+    validations:
+      required: false


### PR DESCRIPTION
## Summary
- Adds bug report template that collects MCP client, auth type, OAuth scopes, server config, failing endpoint, reproduction steps, and logs
- Adds feature request template
- Adds config with link to Cloudflare MCP docs and blank issues enabled

Prompted by needing structured reproduction info on issues like #33.

## Test plan
- [ ] Verify templates render correctly on the repo's "New Issue" page