### PR TITLE
docs: disable blank issues and remove contact link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,1 @@
-blank_issues_enabled: true
-contact_links:
-  - name: Cloudflare MCP Documentation
-    url: https://developers.cloudflare.com/agents/model-context-protocol/
-    about: Check the official documentation before opening an issue
+blank_issues_enabled: false


### PR DESCRIPTION
## Summary
- Disables blank issues so reporters must use the bug report or feature request templates
- Removes the Cloudflare MCP Documentation contact link

## Test plan
- [ ] Verify "New Issue" page only shows bug report and feature request options