### PR TITLE
fix: use opaque state parameter in OAuth authorization flow

### DIFF
--- a/src/auth/cloudflare-auth.ts
+++ b/src/auth/cloudflare-auth.ts
@@ -1,7 +1,5 @@
 import { z } from 'zod'
 
-import type { AuthRequest } from '@cloudflare/workers-oauth-provider'
-
 import { OAuthError } from './workers-oauth-utils'
 
 /**
@@ -71,7 +69,7 @@ export async function generatePKCECodes(): Promise<PKCECodes> {
 export async function getAuthorizationURL(params: {
   client_id: string
   redirect_uri: string
-  state: AuthRequest
+  stateToken: string
   scopes: string[]
   codeChallenge: string
   oauthDomain: string
@@ -80,7 +78,7 @@ export async function getAuthorizationURL(params: {
     response_type: 'code',
     client_id: params.client_id,
     redirect_uri: params.redirect_uri,
-    state: btoa(JSON.stringify(params.state)),
+    state: params.stateToken,
     code_challenge: params.codeChallenge,
     code_challenge_method: 'S256',
     scope: params.scopes.join(' ')

--- a/src/auth/oauth-handler.ts
+++ b/src/auth/oauth-handler.ts
@@ -558,21 +558,15 @@ export async function handleTokenExchangeCallback(
  */
 async function redirectToCloudflare(
   requestUrl: string,
-  oauthReqInfo: AuthRequest,
   stateToken: string,
   codeChallenge: string,
   scopes: string[],
   additionalHeaders: Record<string, string> = {}
 ): Promise<Response> {
-  const stateWithToken: AuthRequest = {
-    ...oauthReqInfo,
-    state: stateToken
-  }
-
   const { authUrl } = await getAuthorizationURL({
     client_id: env.CLOUDFLARE_CLIENT_ID,
     redirect_uri: new URL('/oauth/callback', requestUrl).href,
-    state: stateWithToken,
+    stateToken,
     scopes,
     codeChallenge,
     oauthDomain: env.CLOUDFLARE_OAUTH_DOMAIN
@@ -617,16 +611,9 @@ export function createAuthHandlers() {
         const stateToken = await createOAuthState(oauthReqInfo, env.OAUTH_KV, codeVerifier)
         const { setCookie: sessionCookie } = await bindStateToSession(stateToken)
 
-        return redirectToCloudflare(
-          c.req.url,
-          oauthReqInfo,
-          stateToken,
-          codeChallenge,
-          defaultScopes,
-          {
-            'Set-Cookie': sessionCookie
-          }
-        )
+        return redirectToCloudflare(c.req.url, stateToken, codeChallenge, defaultScopes, {
+          'Set-Cookie': sessionCookie
+        })
       }
 
       // Client not approved - show consent dialog with scope selection
@@ -691,7 +678,6 @@ export function createAuthHandlers() {
 
       const redirectResponse = await redirectToCloudflare(
         c.req.url,
-        oauthReqInfo,
         stateToken,
         codeChallenge,
         scopesToRequest

--- a/src/auth/workers-oauth-utils.ts
+++ b/src/auth/workers-oauth-utils.ts
@@ -1754,17 +1754,7 @@ export async function validateOAuthState(
     throw new OAuthError('invalid_request', 'Missing state parameter')
   }
 
-  // Decode state to extract embedded stateToken
-  let stateToken: string
-  try {
-    const decodedState = JSON.parse(atob(stateFromQuery))
-    stateToken = decodedState.state
-    if (!stateToken) {
-      throw new Error('State token not found')
-    }
-  } catch {
-    throw new OAuthError('invalid_request', 'Failed to decode state')
-  }
+  const stateToken = stateFromQuery
 
   // Validate state exists in KV
   const storedDataJson = await kv.get(`oauth:state:${stateToken}`)

--- a/src/auth/workers-oauth-utils.ts
+++ b/src/auth/workers-oauth-utils.ts
@@ -10,6 +10,19 @@ const APPROVED_CLIENTS_COOKIE = '__Host-MCP_APPROVED_CLIENTS'
 const CSRF_COOKIE = '__Host-CSRF_TOKEN'
 const STATE_COOKIE = '__Host-CONSENTED_STATE'
 const ONE_YEAR_IN_SECONDS = 31536000
+const OAuthStateToken = z.uuid()
+
+function encodeBase64Utf8(value: string): string {
+  const bytes = new TextEncoder().encode(value)
+  let binary = ''
+  for (const byte of bytes) binary += String.fromCharCode(byte)
+  return btoa(binary)
+}
+
+function decodeBase64Utf8(value: string): string {
+  const binary = atob(value)
+  return new TextDecoder().decode(Uint8Array.from(binary, (char) => char.charCodeAt(0)))
+}
 
 /**
  * OAuth error class for handling OAuth-specific errors
@@ -449,7 +462,7 @@ export function renderApprovalDialog(request: Request, options: ApprovalDialogOp
     requiredScopes = []
   } = options
 
-  const encodedState = btoa(JSON.stringify(state))
+  const encodedState = encodeBase64Utf8(JSON.stringify(state))
   const clientName = client?.clientName ? sanitizeHtml(client.clientName) : 'Unknown MCP Client'
   const requiredSet = new Set(requiredScopes)
   const categories = groupScopesByCategory(allScopes, requiredSet)
@@ -1469,7 +1482,7 @@ export async function parseRedirectApproval(
     throw new OAuthError('invalid_request', 'Missing state')
   }
 
-  const state = JSON.parse(atob(encodedState))
+  const state = JSON.parse(decodeBase64Utf8(encodedState))
   if (!state.oauthReqInfo || !state.oauthReqInfo.clientId) {
     throw new OAuthError('invalid_request', 'Invalid state data')
   }
@@ -1754,10 +1767,13 @@ export async function validateOAuthState(
     throw new OAuthError('invalid_request', 'Missing state parameter')
   }
 
-  const stateToken = stateFromQuery
+  const stateToken = OAuthStateToken.safeParse(stateFromQuery)
+  if (!stateToken.success) {
+    throw new OAuthError('invalid_request', 'Invalid state parameter')
+  }
 
   // Validate state exists in KV
-  const storedDataJson = await kv.get(`oauth:state:${stateToken}`)
+  const storedDataJson = await kv.get(`oauth:state:${stateToken.data}`)
   if (!storedDataJson) {
     throw new OAuthError('invalid_request', 'Invalid or expired state')
   }
@@ -1774,7 +1790,7 @@ export async function validateOAuthState(
 
   // Verify hash matches
   const encoder = new TextEncoder()
-  const hashBuffer = await crypto.subtle.digest('SHA-256', encoder.encode(stateToken))
+  const hashBuffer = await crypto.subtle.digest('SHA-256', encoder.encode(stateToken.data))
   const expectedHash = Array.from(new Uint8Array(hashBuffer))
     .map((b) => b.toString(16).padStart(2, '0'))
     .join('')
@@ -1790,7 +1806,7 @@ export async function validateOAuthState(
   }
 
   // Delete state (single use)
-  await kv.delete(`oauth:state:${stateToken}`)
+  await kv.delete(`oauth:state:${stateToken.data}`)
 
   return {
     oauthReqInfo: parseResult.data.oauthReqInfo as AuthRequest,

--- a/src/auth/workers-oauth-utils.ts
+++ b/src/auth/workers-oauth-utils.ts
@@ -11,6 +11,8 @@ const CSRF_COOKIE = '__Host-CSRF_TOKEN'
 const STATE_COOKIE = '__Host-CONSENTED_STATE'
 const ONE_YEAR_IN_SECONDS = 31536000
 const OAuthStateToken = z.uuid()
+const LegacyOAuthState = z.object({ state: OAuthStateToken }).passthrough()
+const MAX_LEGACY_OAUTH_STATE_LENGTH = 32_768
 
 function encodeBase64Utf8(value: string): string {
   const bytes = new TextEncoder().encode(value)
@@ -22,6 +24,21 @@ function encodeBase64Utf8(value: string): string {
 function decodeBase64Utf8(value: string): string {
   const binary = atob(value)
   return new TextDecoder().decode(Uint8Array.from(binary, (char) => char.charCodeAt(0)))
+}
+
+function parseOAuthStateToken(state: string): string | undefined {
+  const current = OAuthStateToken.safeParse(state)
+  if (current.success) return current.data
+
+  // TODO: Remove this legacy base64-JSON reader after all OAuth flows started
+  // before the opaque-state deployment have exceeded the 600-second KV TTL.
+  if (state.length > MAX_LEGACY_OAUTH_STATE_LENGTH) return undefined
+  try {
+    const legacy = LegacyOAuthState.safeParse(JSON.parse(atob(state)))
+    return legacy.success ? legacy.data.state : undefined
+  } catch {
+    return undefined
+  }
 }
 
 /**
@@ -1767,13 +1784,13 @@ export async function validateOAuthState(
     throw new OAuthError('invalid_request', 'Missing state parameter')
   }
 
-  const stateToken = OAuthStateToken.safeParse(stateFromQuery)
-  if (!stateToken.success) {
+  const stateToken = parseOAuthStateToken(stateFromQuery)
+  if (!stateToken) {
     throw new OAuthError('invalid_request', 'Invalid state parameter')
   }
 
   // Validate state exists in KV
-  const storedDataJson = await kv.get(`oauth:state:${stateToken.data}`)
+  const storedDataJson = await kv.get(`oauth:state:${stateToken}`)
   if (!storedDataJson) {
     throw new OAuthError('invalid_request', 'Invalid or expired state')
   }
@@ -1790,7 +1807,7 @@ export async function validateOAuthState(
 
   // Verify hash matches
   const encoder = new TextEncoder()
-  const hashBuffer = await crypto.subtle.digest('SHA-256', encoder.encode(stateToken.data))
+  const hashBuffer = await crypto.subtle.digest('SHA-256', encoder.encode(stateToken))
   const expectedHash = Array.from(new Uint8Array(hashBuffer))
     .map((b) => b.toString(16).padStart(2, '0'))
     .join('')
@@ -1806,7 +1823,7 @@ export async function validateOAuthState(
   }
 
   // Delete state (single use)
-  await kv.delete(`oauth:state:${stateToken.data}`)
+  await kv.delete(`oauth:state:${stateToken}`)
 
   return {
     oauthReqInfo: parseResult.data.oauthReqInfo as AuthRequest,

--- a/tests/auth/cloudflare-auth.test.ts
+++ b/tests/auth/cloudflare-auth.test.ts
@@ -92,12 +92,12 @@ describe('generatePKCECodes', () => {
 })
 
 describe('getAuthorizationURL', () => {
-  it('builds the Cloudflare /oauth2/auth URL with S256 PKCE and encoded state', async () => {
-    const state = { clientId: 'mcp-client', redirectUri: 'https://app/cb' } as never
+  it('builds the Cloudflare /oauth2/auth URL with S256 PKCE and an opaque state token', async () => {
+    const stateToken = 'b9f1c0de-1234-4abc-9def-0123456789ab'
     const { authUrl } = await getAuthorizationURL({
       client_id: 'client-id',
       redirect_uri: 'https://mcp.example.com/oauth/callback',
-      state,
+      stateToken,
       scopes: ['user:read', 'account:read'],
       codeChallenge: 'challenge-123',
       oauthDomain: OAUTH_DOMAIN
@@ -111,8 +111,8 @@ describe('getAuthorizationURL', () => {
     expect(url.searchParams.get('code_challenge')).toBe('challenge-123')
     expect(url.searchParams.get('code_challenge_method')).toBe('S256')
     expect(url.searchParams.get('scope')).toBe('user:read account:read')
-    // State is base64-encoded JSON of the AuthRequest.
-    expect(JSON.parse(atob(url.searchParams.get('state')!))).toEqual(state)
+    // State is the opaque KV lookup token, passed through verbatim (RFC 6749 §10.12).
+    expect(url.searchParams.get('state')).toBe(stateToken)
   })
 })
 

--- a/tests/auth/oauth-routes.test.ts
+++ b/tests/auth/oauth-routes.test.ts
@@ -148,6 +148,18 @@ describe('GET /oauth/callback', () => {
     const cfState = new URL(postRes.headers.get('location')!).searchParams.get('state')!
     const sessionCookie = cookiesFrom(postRes)
 
+    // The state forwarded to Cloudflare is an opaque token (RFC 6749 §10.12),
+    // not a base64-encoded AuthRequest. Decoding it must NOT yield JSON with
+    // request fields like client_id/redirect_uri (the pre-opaque-state shape).
+    let decodedAsJson: unknown
+    try {
+      decodedAsJson = JSON.parse(atob(cfState))
+    } catch {
+      decodedAsJson = null
+    }
+    expect(decodedAsJson).not.toMatchObject({ clientId: expect.anything() })
+    expect(decodedAsJson).not.toMatchObject({ redirectUri: expect.anything() })
+
     // 3. Mock the upstream the callback talks to: token exchange + identity.
     server.use(
       http.post('https://dash.cloudflare.com/oauth2/token', () =>
@@ -209,10 +221,11 @@ describe('GET /oauth/callback', () => {
   })
 
   it('rejects an unknown/expired state token', async () => {
-    const stateQuery = btoa(JSON.stringify({ clientId: 'c', state: 'never-stored' }))
+    // State is now used directly as the KV lookup key; an unknown opaque token
+    // has no KV entry and is rejected.
     const res = await exports.default.fetch(
       new Request(
-        `https://mcp.example.com/oauth/callback?code=authcode&state=${encodeURIComponent(stateQuery)}`,
+        'https://mcp.example.com/oauth/callback?code=authcode&state=never-stored',
         { headers: { Cookie: '__Host-CONSENTED_STATE=deadbeef' } }
       )
     )

--- a/tests/auth/oauth-routes.test.ts
+++ b/tests/auth/oauth-routes.test.ts
@@ -41,6 +41,70 @@ function authorizeUrl(params: Record<string, string>): string {
   return u.toString()
 }
 
+async function beginAuthorization(options: { state?: string; scopes?: string } = {}): Promise<{
+  state: string
+  sessionCookie: string
+  location: string
+}> {
+  const clientId = await registerClient()
+  const authRes = await exports.default.fetch(
+    new Request(
+      authorizeUrl({
+        response_type: 'code',
+        client_id: clientId,
+        redirect_uri: REDIRECT_URI,
+        scope: 'user:read',
+        ...(options.state === undefined ? {} : { state: options.state })
+      })
+    )
+  )
+  const html = await authRes.text()
+  const csrfCookie = cookiesFrom(authRes)
+  const stateField = html.match(/name="state" value="([^"]+)"/)?.[1]
+  const csrfField = html.match(/name="csrf_token" value="([^"]+)"/)?.[1]
+  expect(stateField && csrfField).toBeTruthy()
+
+  const postRes = await exports.default.fetch(
+    new Request('https://mcp.example.com/authorize', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded', Cookie: csrfCookie },
+      body: new URLSearchParams({
+        state: stateField!,
+        csrf_token: csrfField!,
+        scopes: options.scopes ?? 'user:read'
+      }).toString(),
+      redirect: 'manual'
+    })
+  )
+  expect(postRes.status).toBe(302)
+  const location = postRes.headers.get('location')!
+  return {
+    state: new URL(location).searchParams.get('state')!,
+    sessionCookie: cookiesFrom(postRes),
+    location
+  }
+}
+
+function useCloudflareAuthSuccess(): void {
+  server.use(
+    http.post('https://dash.cloudflare.com/oauth2/token', () =>
+      HttpResponse.json({
+        access_token: 'access-token',
+        expires_in: 3600,
+        refresh_token: 'refresh-token',
+        scope: 'user:read',
+        token_type: 'bearer'
+      })
+    ),
+    http.get('https://api.cloudflare.com/client/v4/user', () =>
+      HttpResponse.json(cfSuccess({ id: 'user-1', email: 'user@example.com' }))
+    ),
+    http.get('https://api.cloudflare.com/client/v4/accounts', () =>
+      HttpResponse.json(cfAccountsSuccess([{ id: 'acc-1', name: 'Account One' }]))
+    )
+  )
+}
+
 /** Collapse a response's Set-Cookie header(s) into a Cookie request header. */
 function cookiesFrom(res: Response): string {
   const raw = res.headers.getSetCookie?.() ?? [res.headers.get('set-cookie') ?? '']
@@ -112,41 +176,7 @@ describe('GET /authorize', () => {
 
 describe('GET /oauth/callback', () => {
   it('completes the full login flow and redirects back to the client with a code', async () => {
-    const clientId = await registerClient()
-
-    // 1. GET /authorize -> consent dialog (CSRF cookie + hidden state/csrf).
-    const authRes = await exports.default.fetch(
-      new Request(
-        authorizeUrl({
-          response_type: 'code',
-          client_id: clientId,
-          redirect_uri: REDIRECT_URI,
-          scope: 'user:read'
-        })
-      )
-    )
-    const html = await authRes.text()
-    const csrfCookie = cookiesFrom(authRes)
-    const stateField = html.match(/name="state" value="([^"]+)"/)?.[1]
-    const csrfField = html.match(/name="csrf_token" value="([^"]+)"/)?.[1]
-    expect(stateField && csrfField).toBeTruthy()
-
-    // 2. POST /authorize (consent) -> 302 to Cloudflare carrying the state token.
-    const postRes = await exports.default.fetch(
-      new Request('https://mcp.example.com/authorize', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded', Cookie: csrfCookie },
-        body: new URLSearchParams({
-          state: stateField!,
-          csrf_token: csrfField!,
-          scopes: 'user:read'
-        }).toString(),
-        redirect: 'manual'
-      })
-    )
-    expect(postRes.status).toBe(302)
-    const cfState = new URL(postRes.headers.get('location')!).searchParams.get('state')!
-    const sessionCookie = cookiesFrom(postRes)
+    const { state: cfState, sessionCookie } = await beginAuthorization()
 
     // The state forwarded to Cloudflare is an opaque token (RFC 6749 §10.12),
     // not a base64-encoded AuthRequest. Decoding it must NOT yield JSON with
@@ -160,26 +190,9 @@ describe('GET /oauth/callback', () => {
     expect(decodedAsJson).not.toMatchObject({ clientId: expect.anything() })
     expect(decodedAsJson).not.toMatchObject({ redirectUri: expect.anything() })
 
-    // 3. Mock the upstream the callback talks to: token exchange + identity.
-    server.use(
-      http.post('https://dash.cloudflare.com/oauth2/token', () =>
-        HttpResponse.json({
-          access_token: 'access-token',
-          expires_in: 3600,
-          refresh_token: 'refresh-token',
-          scope: 'user:read',
-          token_type: 'bearer'
-        })
-      ),
-      http.get('https://api.cloudflare.com/client/v4/user', () =>
-        HttpResponse.json(cfSuccess({ id: 'user-1', email: 'user@example.com' }))
-      ),
-      http.get('https://api.cloudflare.com/client/v4/accounts', () =>
-        HttpResponse.json(cfAccountsSuccess([{ id: 'acc-1', name: 'Account One' }]))
-      )
-    )
+    useCloudflareAuthSuccess()
 
-    // 4. GET /oauth/callback -> 302 back to the client redirect URI with a code.
+    // GET /oauth/callback -> 302 back to the client redirect URI with a code.
     const cbRes = await exports.default.fetch(
       new Request(
         `https://mcp.example.com/oauth/callback?code=authcode&state=${encodeURIComponent(cfState)}`,
@@ -203,6 +216,77 @@ describe('GET /oauth/callback', () => {
     expect(dp.blobs?.[3]).toBeFalsy()
   })
 
+  it('preserves Unicode downstream client state without encoding it into upstream state', async () => {
+    const downstreamState = 'client-state-🔐-你好'
+    const { state, sessionCookie } = await beginAuthorization({ state: downstreamState })
+    expect(state).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i)
+
+    useCloudflareAuthSuccess()
+    const res = await exports.default.fetch(
+      new Request(
+        `https://mcp.example.com/oauth/callback?code=authcode&state=${encodeURIComponent(state)}`,
+        { headers: { Cookie: sessionCookie }, redirect: 'manual' }
+      )
+    )
+
+    expect(res.status).toBe(302)
+    expect(new URL(res.headers.get('location')!).searchParams.get('state')).toBe(downstreamState)
+  })
+
+  it('keeps the upstream authorization URL bounded for large downstream state', async () => {
+    const short = await beginAuthorization({ state: 'short' })
+    const large = await beginAuthorization({ state: 'x'.repeat(8192) })
+
+    expect(large.location.length).toBe(short.location.length)
+    expect(large.location.length).toBeLessThan(2048)
+  })
+
+  it('rejects a valid state token without its session-binding cookie', async () => {
+    const { state } = await beginAuthorization()
+
+    const res = await exports.default.fetch(
+      new Request(
+        `https://mcp.example.com/oauth/callback?code=authcode&state=${encodeURIComponent(state)}`,
+        { redirect: 'manual' }
+      )
+    )
+
+    expect(res.status).toBe(400)
+    expect(await res.text()).toContain('Missing session binding')
+  })
+
+  it('rejects a valid state token bound to a different browser session', async () => {
+    const first = await beginAuthorization()
+    const second = await beginAuthorization()
+
+    const res = await exports.default.fetch(
+      new Request(
+        `https://mcp.example.com/oauth/callback?code=authcode&state=${encodeURIComponent(first.state)}`,
+        { headers: { Cookie: second.sessionCookie }, redirect: 'manual' }
+      )
+    )
+
+    expect(res.status).toBe(400)
+    expect(await res.text()).toContain('State mismatch')
+  })
+
+  it('rejects replay after a state token has completed authorization', async () => {
+    const { state, sessionCookie } = await beginAuthorization()
+    useCloudflareAuthSuccess()
+    const callbackUrl = `https://mcp.example.com/oauth/callback?code=authcode&state=${encodeURIComponent(state)}`
+
+    const first = await exports.default.fetch(
+      new Request(callbackUrl, { headers: { Cookie: sessionCookie }, redirect: 'manual' })
+    )
+    expect(first.status).toBe(302)
+
+    const replay = await exports.default.fetch(
+      new Request(callbackUrl, { headers: { Cookie: sessionCookie }, redirect: 'manual' })
+    )
+    expect(replay.status).toBe(400)
+    expect(await replay.text()).toContain('Invalid or expired state')
+  })
+
   it('returns 400 invalid_request when the code is missing', async () => {
     const res = await exports.default.fetch(new Request('https://mcp.example.com/oauth/callback'))
 
@@ -220,12 +304,14 @@ describe('GET /oauth/callback', () => {
     expect(writtenEvents(metricsSpy)).toContain('auth_user')
   })
 
-  it('rejects an unknown/expired state token', async () => {
-    // State is now used directly as the KV lookup key; an unknown opaque token
-    // has no KV entry and is rejected.
+  it.each([
+    ['unknown', crypto.randomUUID()],
+    ['malformed', 'not-a-uuid'],
+    ['oversized', 'x'.repeat(1024)]
+  ])('rejects an %s state token as invalid_request', async (_, state) => {
     const res = await exports.default.fetch(
       new Request(
-        'https://mcp.example.com/oauth/callback?code=authcode&state=never-stored',
+        `https://mcp.example.com/oauth/callback?code=authcode&state=${encodeURIComponent(state)}`,
         { headers: { Cookie: '__Host-CONSENTED_STATE=deadbeef' } }
       )
     )

--- a/tests/auth/oauth-routes.test.ts
+++ b/tests/auth/oauth-routes.test.ts
@@ -241,6 +241,24 @@ describe('GET /oauth/callback', () => {
     expect(large.location.length).toBeLessThan(2048)
   })
 
+  it('accepts an in-flight legacy base64-JSON state during deployment', async () => {
+    const { state, sessionCookie } = await beginAuthorization()
+    const legacyState = btoa(JSON.stringify({ state }))
+    useCloudflareAuthSuccess()
+
+    const res = await exports.default.fetch(
+      new Request(
+        `https://mcp.example.com/oauth/callback?code=authcode&state=${encodeURIComponent(legacyState)}`,
+        { headers: { Cookie: sessionCookie }, redirect: 'manual' }
+      )
+    )
+
+    expect(res.status).toBe(302)
+    expect(
+      new URL(res.headers.get('location')!).origin + new URL(res.headers.get('location')!).pathname
+    ).toBe(REDIRECT_URI)
+  })
+
   it('rejects a valid state token without its session-binding cookie', async () => {
     const { state } = await beginAuthorization()
 


### PR DESCRIPTION
## Summary

- Replace the base64-encoded downstream `AuthRequest` in the upstream Cloudflare OAuth `state` parameter with an opaque UUID token.
- Keep the full authorization request and PKCE verifier only in the existing server-side KV record.
- Validate callback state as a UUID before accessing KV.
- Temporarily accept the legacy base64-JSON state shape so in-flight authorization flows survive deployment; the fallback is bounded, UUID-validated, and marked with a removal TODO after the 600-second state TTL.
- Make the internal consent-form state transport UTF-8-safe.
- Add end-to-end security and regression coverage for session binding, replay, malformed input, Unicode, and large downstream state.

## Why

The complete downstream authorization request is already stored by `createOAuthState()` under a random UUID with a 10-minute TTL. Sending a second copy through the upstream Cloudflare authorization URL is redundant. The callback currently decodes that copy only to recover the UUID and load the authoritative KV record.

Using the UUID directly keeps the upstream URL bounded regardless of downstream client metadata or client `state`, avoids unnecessarily forwarding downstream client details to the upstream authorization server, and follows OAuth's definition of `state` as an opaque value.

The original PR was motivated by a 5,120-byte authorization endpoint limit observed at the time. That exact threshold is no longer reproducible, but the structural issue remains: client-controlled fields are duplicated and base64-amplified in the URL. Current examples with 78 scopes are roughly:

- short downstream state: ~3.9 KB before, ~1.7 KB after;
- 1 KiB downstream state: ~5.3 KB before, ~1.7 KB after;
- 2 KiB downstream state: ~6.7 KB before, ~1.7 KB after.

The previous Latin-1-only consent state encoding also threw on valid Unicode client state. The internal consent transport now encodes JSON as UTF-8 before base64 encoding.

## Security properties

The change preserves and tests the existing protections:

- **Opaque random state**: generated with `crypto.randomUUID()`.
- **Server-side state**: the original `AuthRequest` and PKCE verifier remain in KV.
- **Short expiry**: the KV state record expires after 600 seconds.
- **Session binding**: a SHA-256 hash of the UUID is stored in an `HttpOnly; Secure; SameSite=Lax` cookie and verified on callback.
- **Single use**: the KV state record is deleted after successful validation.
- **PKCE**: S256 behavior is unchanged.
- **Input validation**: malformed and oversized callback state values are rejected as `invalid_request` before KV access.
- **Downstream state preservation**: the MCP client's original state remains in the stored `AuthRequest` and is returned by `completeAuthorization()`.

## Test coverage

- [x] Full OAuth flow completes and returns the downstream client state.
- [x] Upstream Cloudflare state is an opaque UUID, not a serialized `AuthRequest`.
- [x] Unicode downstream client state survives the complete flow unchanged.
- [x] An 8 KiB downstream state does not increase the upstream authorization URL.
- [x] Missing state is rejected.
- [x] Unknown/expired state is rejected.
- [x] An in-flight legacy base64-JSON state completes during deployment.
- [x] Malformed state is rejected before KV access.
- [x] Oversized callback state is rejected before KV access.
- [x] Missing session-binding cookie is rejected.
- [x] State bound to a different browser session is rejected.
- [x] Replay after successful authorization is rejected.
- [x] Full repository gate passes: format, lint, typecheck, and **263 tests across 16 files**.

## Maintenance

Rebased onto current `main` before updating the implementation and tests.
