### PR TITLE
fix: use zone ID placeholder instead of accountId for zoneTag in GraphQL example

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ execute({
       body: {
         query: \`query {
           viewer {
-            zones(filter: { zoneTag: "\${accountId}" }) {
+            zones(filter: { zoneTag: "your-zone-id" }) {
               httpRequests1dGroups(limit: 7, orderBy: [date_ASC]) {
                 dimensions {
                   date


### PR DESCRIPTION
This PR fixes the GraphQL example in the README which used `${accountId}` as the `zoneTag` filter value. The `zoneTag` field expects a zone ID, not an account ID, so this would return no results for anyone who copied it.

Replaced with a `"your-zone-id"` placeholder.

Fixes #59.