### PR TITLE
feat: JIT scope upgrade via ElicitationAgent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@cloudflare/workers-oauth-provider": "^0.3.0",
         "@modelcontextprotocol/sdk": "^1.26.0",
+        "agents": "^0.7.5",
         "hono": "^4.12.3",
         "zod": "^4.3.5"
       },
@@ -23,6 +24,97 @@
         "vitest": "3.2",
         "wrangler": "^4.64.0"
       }
+    },
+    "node_modules/@ai-sdk/gateway": {
+      "version": "3.0.66",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.66.tgz",
+      "integrity": "sha512-SIQ0YY0iMuv+07HLsZ+bB990zUJ6S4ujORAh+Jv1V2KGNn73qQKnGO0JBk+w+Res8YqOFSycwDoWcFlQrVxS4A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.19",
+        "@vercel/oidc": "3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
+      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.19",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.19.tgz",
+      "integrity": "sha512-3eG55CrSWCu2SXlqq2QCsFjo3+E7+Gmg7i/oRVoSZzIodTuDSfLb3MRje67xE9RFea73Zao7Lm4mADIfUETKGg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.6"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "11.9.3",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.9.3.tgz",
+      "integrity": "sha512-60vepv88RwcJtSHrD6MjIL6Ta3SOYbgfnkHb+ppAVK+o9mXprRtulx7VlRl3lN3bbvysAfCS7WMVfhUYemB0IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.15",
+        "js-yaml": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/philsturgeon"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/runtime-corejs3": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.29.0.tgz",
+      "integrity": "sha512-TgUkdp71C9pIbBcHudc+gXZnihEDOjUAmXO1VO4HHGES7QLZcShR0stfKIxLSNIYx2fqhmJChOjm/wkF8wv4gA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-js-pure": "^3.48.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@cfworker/json-schema": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.1.1.tgz",
+      "integrity": "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@cloudflare/kv-asset-handler": {
       "version": "0.4.2",
@@ -158,6 +250,13 @@
       "resolved": "https://registry.npmjs.org/@cloudflare/workers-oauth-provider/-/workers-oauth-provider-0.3.0.tgz",
       "integrity": "sha512-I39kyUzNQWxVTIQs56xbnnHSrOY5UjiGKVeYI2zY5h+LjUxqeiuOBTTlKEDUirRvnMmBg3yppA6pR8bYKBrTAA==",
       "license": "MIT"
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20260305.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260305.1.tgz",
+      "integrity": "sha512-835BZaIcgjuYIUqgOWJSpwQxFSJ8g/X1OCZFLO7bmirM6TGmVgIGwiGItBgkjUXXCPrYzJEldsJkuFuK7ePuMw==",
+      "license": "MIT OR Apache-2.0",
+      "peer": true
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -1155,6 +1254,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
+      "license": "MIT"
+    },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.26.0",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
@@ -1193,6 +1298,15 @@
         "zod": {
           "optional": false
         }
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/@oxfmt/binding-android-arm-eabi": {
@@ -2240,6 +2354,12 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -2265,6 +2385,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.24",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
+      "integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "25.0.6",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.6.tgz",
@@ -2274,6 +2406,15 @@
       "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@vercel/oidc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.1.0.tgz",
+      "integrity": "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/@vitest/expect": {
@@ -2406,6 +2547,103 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/agents": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/agents/-/agents-0.7.5.tgz",
+      "integrity": "sha512-sB37uMLt4aenYJwhbCSnIaYZuepoJwXYTX/8WXJGFj/FuWoScHrY+o2LrxKgzSmDA4pMMn4JIXaq/wMHs8OAJg==",
+      "license": "MIT",
+      "dependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "@modelcontextprotocol/sdk": "1.26.0",
+        "cron-schedule": "^6.0.0",
+        "json-schema": "^0.4.0",
+        "json-schema-to-typescript": "^15.0.4",
+        "mimetext": "^3.0.28",
+        "nanoid": "^5.1.6",
+        "partyserver": "^0.3.3",
+        "partysocket": "1.1.16",
+        "yargs": "^18.0.0"
+      },
+      "bin": {
+        "agents": "dist/cli/index.js"
+      },
+      "peerDependencies": {
+        "@ai-sdk/openai": "^3.0.0",
+        "@ai-sdk/react": "^3.0.0",
+        "@cloudflare/ai-chat": "^0.1.8",
+        "@cloudflare/codemode": "^0.1.2",
+        "@x402/core": "^2.0.0",
+        "@x402/evm": "^2.0.0",
+        "ai": "^6.0.0",
+        "just-bash": "^2.11.0",
+        "react": "^19.0.0",
+        "viem": ">=2.0.0",
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@ai-sdk/openai": {
+          "optional": true
+        },
+        "@ai-sdk/react": {
+          "optional": true
+        },
+        "@cloudflare/ai-chat": {
+          "optional": true
+        },
+        "@cloudflare/codemode": {
+          "optional": true
+        },
+        "@x402/core": {
+          "optional": true
+        },
+        "@x402/evm": {
+          "optional": true
+        },
+        "just-bash": {
+          "optional": true
+        },
+        "viem": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/agents/node_modules/nanoid": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.6.tgz",
+      "integrity": "sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
+    },
+    "node_modules/ai": {
+      "version": "6.0.116",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.116.tgz",
+      "integrity": "sha512-7yM+cTmyRLeNIXwt4Vj+mrrJgVQ9RMIW5WO0ydoLoYkewIvsMcvUmqS4j2RJTUXaF1HphwmSKUMQ/HypNRGOmA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@ai-sdk/gateway": "3.0.66",
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.19",
+        "@opentelemetry/api": "1.9.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
     "node_modules/ajv": {
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
@@ -2438,6 +2676,36 @@
           "optional": true
         }
       }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -2562,6 +2830,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/content-disposition": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
@@ -2602,6 +2884,17 @@
         "node": ">=6.6.0"
       }
     },
+    "node_modules/core-js-pure": {
+      "version": "3.48.0",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.48.0.tgz",
+      "integrity": "sha512-1slJgk89tWC51HQ1AEqG+s2VuwpTRr8ocu4n20QUcH1v9lAN0RXen0Q0AABa/DK1I7RrNWLucplOHMx8hfTGTw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/cors": {
       "version": "2.8.5",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
@@ -2613,6 +2906,15 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/cron-schedule": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cron-schedule/-/cron-schedule-6.0.0.tgz",
+      "integrity": "sha512-BoZaseYGXOo5j5HUwTaegIog3JJbuH4BbrY9A1ArLjXpy+RWb3mV28F/9Gv1dDA7E2L8kngWva4NWisnLTyfgQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/cross-spawn": {
@@ -2693,6 +2995,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -2793,6 +3101,15 @@
         "@esbuild/win32-x64": "0.27.3"
       }
     },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -2817,6 +3134,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/event-target-polyfill": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/event-target-polyfill/-/event-target-polyfill-0.0.4.tgz",
+      "integrity": "sha512-Gs6RLjzlLRdT8X9ZipJdIZI/Y6/HhRLyq9RdDlCsnpxr/+Nn6bU2EFGuC94GjxqhM+Nmij2Vcq98yoHrU8uNFQ==",
+      "license": "MIT"
     },
     "node_modules/eventsource": {
       "version": "3.0.7",
@@ -2937,7 +3260,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -3012,6 +3334,27 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-intrinsic": {
@@ -3170,6 +3513,27 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -3191,12 +3555,59 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/js-base64": {
+      "version": "3.7.8",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.8.tgz",
+      "integrity": "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/js-tokens": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
+    "node_modules/json-schema-to-typescript": {
+      "version": "15.0.4",
+      "resolved": "https://registry.npmjs.org/json-schema-to-typescript/-/json-schema-to-typescript-15.0.4.tgz",
+      "integrity": "sha512-Su9oK8DR4xCmDsLlyvadkXzX6+GGXJpbhwoLtOGArAG61dvbW4YQmSEno2y66ahpIdmLMg6YUf/QHLgiwvkrHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "^11.5.5",
+        "@types/json-schema": "^7.0.15",
+        "@types/lodash": "^4.17.7",
+        "is-glob": "^4.0.3",
+        "js-yaml": "^4.1.0",
+        "lodash": "^4.17.21",
+        "minimist": "^1.2.8",
+        "prettier": "^3.2.5",
+        "tinyglobby": "^0.2.9"
+      },
+      "bin": {
+        "json2ts": "dist/src/cli.js"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
@@ -3219,6 +3630,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "license": "MIT"
     },
     "node_modules/loupe": {
       "version": "3.2.1",
@@ -3292,6 +3709,43 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/mimetext": {
+      "version": "3.0.28",
+      "resolved": "https://registry.npmjs.org/mimetext/-/mimetext-3.0.28.tgz",
+      "integrity": "sha512-eQXpbNrtxLCjUtiVbR/qR09dbPgZ2o+KR1uA7QKqGhbn8QV7HIL16mXXsobBL4/8TqoYh1us31kfz+dNfCev9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.0",
+        "@babel/runtime-corejs3": "^7.26.0",
+        "js-base64": "^3.7.7",
+        "mime-types": "^2.1.35"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://patreon.com/muratgozel"
+      }
+    },
+    "node_modules/mimetext/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimetext/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/miniflare": {
       "version": "4.20260210.0",
       "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260210.0.tgz",
@@ -3311,6 +3765,15 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/ms": {
@@ -3493,6 +3956,53 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/partyserver": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/partyserver/-/partyserver-0.3.3.tgz",
+      "integrity": "sha512-jSGWNZ5lJj9czq+97y9N02HyZZtQH8wmgJRkTQahfGnzgL5+R12dMX3E+p7BscB2cVj6LZLv1uHpKL057rjJmw==",
+      "license": "ISC",
+      "dependencies": {
+        "nanoid": "^5.1.6"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20240729.0"
+      }
+    },
+    "node_modules/partyserver/node_modules/nanoid": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.6.tgz",
+      "integrity": "sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
+    },
+    "node_modules/partysocket": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/partysocket/-/partysocket-1.1.16.tgz",
+      "integrity": "sha512-d7xFv+ZC7x0p/DAHWJ5FhxQhimIx+ucyZY+kxL0cKddLBmK9c4p2tEA/L+dOOrWm6EYrRwrBjKQV0uSzOY9x1w==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-polyfill": "^0.0.4"
+      },
+      "peerDependencies": {
+        "react": ">=17"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -3540,7 +4050,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -3586,6 +4095,21 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/proxy-addr": {
@@ -3638,6 +4162,16 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
+      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/require-from-string": {
@@ -3968,6 +4502,38 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/strip-literal": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
@@ -4012,7 +4578,6 @@
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
       "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -4436,6 +5001,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -4462,6 +5044,41 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^7.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
       }
     },
     "node_modules/youch": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@cloudflare/workers-oauth-provider": "^0.3.0",
     "@modelcontextprotocol/sdk": "^1.26.0",
+    "agents": "^0.7.5",
     "hono": "^4.12.3",
     "zod": "^4.3.5"
   },

--- a/src/auth/oauth-handler.ts
+++ b/src/auth/oauth-handler.ts
@@ -1,4 +1,5 @@
 import { env as cloudflareEnv } from 'cloudflare:workers'
+import { getAgentByName } from 'agents'
 import { Hono } from 'hono'
 import { z } from 'zod'
 
@@ -164,7 +165,8 @@ export async function handleTokenExchangeCallback(
       accessToken: z.string(),
       user: z.object({ id: z.string(), email: z.string() }),
       accounts: z.array(z.object({ id: z.string(), name: z.string() })),
-      refreshToken: z.string().optional()
+      refreshToken: z.string().optional(),
+      scopes: z.array(z.string()).optional()
     })
   ])
 
@@ -365,6 +367,49 @@ export function createAuthHandlers() {
         env.OAUTH_KV
       )
 
+      // ── Scope upgrade flow ──────────────────────────────────────────
+      // If the state was created by ElicitationAgent, handle it as a
+      // scope upgrade instead of a normal OAuth completion.
+      const upgradeInfo = oauthReqInfo as AuthRequest & {
+        elicitationId?: string
+        tokenHash?: string
+        userId?: string
+      }
+
+      if (upgradeInfo.responseType === 'scope_upgrade' && upgradeInfo.elicitationId) {
+        const { access_token, refresh_token } = await getAuthToken({
+          client_id: env.CLOUDFLARE_CLIENT_ID,
+          client_secret: env.CLOUDFLARE_CLIENT_SECRET,
+          redirect_uri: new URL('/oauth/callback', c.req.url).href,
+          code,
+          code_verifier: codeVerifier
+        })
+
+        // Notify the ElicitationAgent of the successful upgrade
+        const stub = await getAgentByName(env.ELICITATION_AGENT, upgradeInfo.elicitationId)
+        await stub.fetch(new Request('https://agent/complete', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            accessToken: access_token,
+            refreshToken: refresh_token,
+            scopes: oauthReqInfo.scope
+          })
+        }))
+
+        // Redirect to elicitation success page
+        const baseUrl = new URL(c.req.url).origin
+        return new Response(null, {
+          status: 302,
+          headers: {
+            Location: `${baseUrl}/elicitation/${upgradeInfo.elicitationId}`,
+            'Set-Cookie': clearCookie
+          }
+        })
+      }
+
+      // ── Normal OAuth flow ───────────────────────────────────────────
+
       if (!oauthReqInfo.clientId) {
         return new OAuthError('invalid_request', 'Invalid OAuth request info').toHtmlResponse()
       }
@@ -407,7 +452,8 @@ export function createAuthHandlers() {
           user,
           accounts,
           accessToken: access_token,
-          refreshToken: refresh_token
+          refreshToken: refresh_token,
+          scopes: oauthReqInfo.scope
         } satisfies AuthProps
       })
 

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -23,7 +23,8 @@ export const UserAuthProps = z.object({
   accessToken: z.string(),
   user: UserSchema,
   accounts: AccountsSchema,
-  refreshToken: z.string().optional()
+  refreshToken: z.string().optional(),
+  scopes: z.array(z.string()).optional()
 })
 
 export const AuthProps = z.discriminatedUnion('type', [AccountAuthProps, UserAuthProps])

--- a/src/elicitation-agent.ts
+++ b/src/elicitation-agent.ts
@@ -1,0 +1,915 @@
+import { Agent } from 'agents'
+import { generatePKCECodes } from './auth/cloudflare-auth'
+import { ALL_SCOPES, SCOPE_TEMPLATES, REQUIRED_SCOPES, MAX_SCOPES } from './auth/scopes'
+import { createOAuthState, bindStateToSession } from './auth/workers-oauth-utils'
+import type { AuthRequest } from '@cloudflare/workers-oauth-provider'
+
+export type ElicitationState = {
+  errorMessage: string
+  currentScopes: string[]
+  tokenHash: string
+  userId: string
+  status: 'pending' | 'upgrading' | 'complete' | 'failed'
+  createdAt: number
+  completedAt?: number
+  newScopes?: string[]
+  failureReason?: string
+} | null
+
+const HTML_HEADERS: Record<string, string> = {
+  'Content-Type': 'text/html; charset=utf-8',
+  'Cache-Control': 'no-store',
+  'Content-Security-Policy': "frame-ancestors 'none'",
+  'X-Frame-Options': 'DENY'
+}
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#x27;')
+}
+
+export class ElicitationAgent extends Agent<Env, ElicitationState> {
+  initialState: ElicitationState = null
+
+  async onStart() {
+    if (this.state && this.state.status === 'pending') {
+      this.schedule(Date.now() + 60 * 60 * 1000, 'cleanup')
+    }
+  }
+
+  async onRequest(request: Request): Promise<Response> {
+    const url = new URL(request.url)
+    // Routes may arrive as /init (internal) or /elicitation/:id (browser).
+    // Normalize by extracting the last path segment.
+    const segments = url.pathname.replace(/\/+$/, '').split('/')
+    const route = segments[segments.length - 1] || ''
+
+    // POST /init — internal call from elicitUpdatedScopes
+    if (request.method === 'POST' && route === 'init') {
+      if (this.state !== null) {
+        return new Response('Conflict: elicitation already initialized', { status: 409 })
+      }
+      const body = (await request.json()) as {
+        errorMessage: string
+        currentScopes: string[]
+        tokenHash: string
+        userId: string
+      }
+      this.setState({
+        errorMessage: body.errorMessage,
+        currentScopes: body.currentScopes,
+        tokenHash: body.tokenHash,
+        userId: body.userId,
+        status: 'pending',
+        createdAt: Date.now()
+      })
+      this.schedule(Date.now() + 60 * 60 * 1000, 'cleanup')
+      return new Response('OK', { status: 200 })
+    }
+
+    // GET — render scope picker page (matches /elicitation/:id or /)
+    if (request.method === 'GET' && (route === this.name || route === '' || !['init', 'upgrade', 'complete', 'fail'].includes(route))) {
+      if (!this.state) return new Response('Not found', { status: 404 })
+
+      if (this.state.status === 'complete') {
+        return new Response(renderCompletePage(this.state.newScopes || []), { headers: HTML_HEADERS })
+      }
+      if (this.state.status === 'failed') {
+        return new Response(renderFailedPage(this.state.failureReason || 'Unknown error'), { headers: HTML_HEADERS })
+      }
+
+      return new Response(renderScopePickerPage(this.state, this.name), { headers: HTML_HEADERS })
+    }
+
+    // POST /upgrade — user submitted new scopes, redirect to Cloudflare OAuth
+    if (request.method === 'POST' && route === 'upgrade') {
+      if (!this.state || this.state.status !== 'pending') {
+        return new Response('Bad request', { status: 400 })
+      }
+
+      const formData = await request.formData()
+      const selectedScopes = formData.getAll('scopes').filter((s): s is string => typeof s === 'string')
+
+      if (selectedScopes.length === 0) {
+        return new Response('No scopes selected', { status: 400 })
+      }
+
+      // Ensure required scopes are included
+      const finalScopes = Array.from(new Set([...REQUIRED_SCOPES, ...selectedScopes])).slice(0, MAX_SCOPES)
+
+      this.setState({ ...this.state, status: 'upgrading', newScopes: finalScopes })
+
+      // Generate PKCE codes
+      const { codeChallenge, codeVerifier } = await generatePKCECodes()
+
+      // Build a synthetic oauthReqInfo for the state. We mark it as a scope_upgrade
+      // so /oauth/callback knows to handle it differently.
+      const oauthReqInfo = {
+        responseType: 'scope_upgrade',
+        clientId: 'scope_upgrade',
+        redirectUri: '',
+        scope: finalScopes,
+        state: '',
+        // Custom fields (preserved by .passthrough() in schema)
+        elicitationId: this.name,
+        tokenHash: this.state.tokenHash,
+        userId: this.state.userId
+      } as AuthRequest & { elicitationId: string; tokenHash: string; userId: string }
+
+      // Store state in OAUTH_KV
+      const stateToken = await createOAuthState(oauthReqInfo, this.env.OAUTH_KV, codeVerifier)
+
+      // Bind state to session cookie
+      const { setCookie: sessionCookie } = await bindStateToSession(stateToken)
+
+      // Build Cloudflare OAuth URL
+      const stateWithToken = { ...oauthReqInfo, state: stateToken }
+      const baseUrl = new URL(request.url).origin
+      const redirectUri = `${baseUrl}/oauth/callback`
+
+      const urlParams = new URLSearchParams({
+        response_type: 'code',
+        client_id: this.env.CLOUDFLARE_CLIENT_ID,
+        redirect_uri: redirectUri,
+        state: btoa(JSON.stringify(stateWithToken)),
+        code_challenge: codeChallenge,
+        code_challenge_method: 'S256',
+        scope: finalScopes.join(' ')
+      })
+
+      const authUrl = `https://dash.cloudflare.com/oauth2/auth?${urlParams.toString()}`
+
+      return new Response(null, {
+        status: 302,
+        headers: {
+          Location: authUrl,
+          'Set-Cookie': sessionCookie
+        }
+      })
+    }
+
+    // POST /complete — called by /oauth/callback after successful scope upgrade
+    if (request.method === 'POST' && route === 'complete') {
+      if (!this.state) {
+        return new Response('Not found', { status: 404 })
+      }
+      const body = (await request.json()) as { accessToken: string; refreshToken: string; scopes: string[] }
+
+      // Store upgraded token in KV, keyed by the old token hash
+      await this.env.OAUTH_KV.put(
+        `token-upgrade:${this.state.tokenHash}`,
+        JSON.stringify({
+          accessToken: body.accessToken,
+          refreshToken: body.refreshToken,
+          scopes: body.scopes,
+          timestamp: Date.now()
+        }),
+        { expirationTtl: 3600 }
+      )
+
+      this.setState({
+        ...this.state,
+        status: 'complete',
+        completedAt: Date.now(),
+        newScopes: body.scopes
+      })
+
+      return new Response('OK', { status: 200 })
+    }
+
+    // POST /fail — called by /oauth/callback on error
+    if (request.method === 'POST' && route === 'fail') {
+      if (!this.state) {
+        return new Response('Not found', { status: 404 })
+      }
+      const body = (await request.json()) as { reason: string }
+      this.setState({ ...this.state, status: 'failed', failureReason: body.reason })
+      return new Response('OK', { status: 200 })
+    }
+
+    return new Response('Method Not Allowed', { status: 405 })
+  }
+
+  async cleanup() {
+    this.setState(null)
+  }
+}
+
+// ── HTML Rendering ──────────────────────────────────────────────────────────
+
+function renderScopePickerPage(state: NonNullable<ElicitationState>, agentId: string): string {
+  const currentScopes = new Set(state.currentScopes)
+
+  // Build scope groups (same categorization as the /authorize page)
+  const scopesByCategory: Record<string, Array<{ scope: string; desc: string; checked: boolean }>> = {}
+  for (const [scope, desc] of Object.entries(ALL_SCOPES)) {
+    const parts = scope.split(':')
+    const category = parts[0].replace(/_/g, ' ')
+    if (!scopesByCategory[category]) {
+      scopesByCategory[category] = []
+    }
+    scopesByCategory[category].push({
+      scope,
+      desc,
+      checked: currentScopes.has(scope)
+    })
+  }
+
+  const scopeGroupsHtml = Object.entries(scopesByCategory)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(
+      ([category, scopes]) => `
+      <div class="scope-group">
+        <div class="scope-group-header">${escapeHtml(category)}</div>
+        ${scopes
+          .map(
+            ({ scope, desc, checked }) => `
+          <label class="scope-item">
+            <input type="checkbox" name="scopes" value="${escapeHtml(scope)}" class="scope-checkbox" ${checked ? 'checked' : ''}>
+            <span class="scope-name">${escapeHtml(scope)}</span>
+            <span class="scope-desc">${escapeHtml(desc)}</span>
+          </label>
+        `
+          )
+          .join('')}
+      </div>
+    `
+    )
+    .join('')
+
+  // Build template options
+  const templateOptionsHtml = Object.entries(SCOPE_TEMPLATES)
+    .map(
+      ([key, template]) => `
+      <label class="template-option">
+        <input type="radio" name="scope_template" value="${escapeHtml(key)}">
+        <div class="template-content">
+          <span class="template-name">${escapeHtml(template.name)}</span>
+          <span class="template-desc">${escapeHtml(template.description)}</span>
+        </div>
+      </label>
+    `
+    )
+    .join('')
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Upgrade Permissions | Cloudflare MCP</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --cf-orange: #f6821f;
+      --cf-orange-hover: #e5750f;
+      --cf-orange-light: rgba(246, 130, 31, 0.08);
+      --cf-brown: #3c2415;
+      --cf-cream: #fbf8f3;
+      --cf-cream-dark: #f5f0e8;
+      --cf-border: rgba(60, 36, 21, 0.1);
+      --cf-border-dark: rgba(60, 36, 21, 0.15);
+      --cf-text: #3c2415;
+      --cf-text-muted: #6b5c52;
+      --cf-text-light: #9a8a7c;
+      --cf-red: #d63031;
+      --border-radius: 8px;
+      --border-radius-lg: 12px;
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+      line-height: 1.5;
+      color: var(--cf-text);
+      background: var(--cf-cream);
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+    .header {
+      padding: 1rem 2rem;
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      border-bottom: 1px solid var(--cf-border);
+      background: white;
+    }
+    .cf-logo { display: flex; align-items: center; gap: 0.5rem; text-decoration: none; }
+    .cf-logo-divider { width: 1px; height: 24px; background: var(--cf-border-dark); margin: 0 0.5rem; }
+    .cf-logo-product { font-size: 0.9rem; color: var(--cf-text-muted); }
+    .main {
+      flex: 1;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 2rem;
+    }
+    .card {
+      background: white;
+      border: 1px solid var(--cf-border);
+      border-radius: var(--border-radius-lg);
+      width: 100%;
+      max-width: 520px;
+      overflow: hidden;
+      box-shadow: 0 4px 24px rgba(60, 36, 21, 0.06);
+    }
+    .card-header {
+      padding: 1.5rem 2rem;
+      border-bottom: 1px solid var(--cf-border);
+      text-align: center;
+    }
+    .card-title { font-size: 1.25rem; font-weight: 600; color: var(--cf-text); margin-bottom: 0.5rem; }
+    .card-subtitle { font-size: 0.875rem; color: var(--cf-text-muted); }
+    .card-body { padding: 1.5rem 2rem; }
+    .warning {
+      background: #fff3cd;
+      color: #856404;
+      padding: 12px 16px;
+      margin-bottom: 1.25rem;
+      border-left: 4px solid #ffc107;
+      border-radius: 4px;
+      font-size: 0.85rem;
+      word-break: break-word;
+    }
+    .scope-section { margin-bottom: 1.25rem; }
+    .scope-label {
+      font-size: 0.75rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: var(--cf-text-muted);
+      margin-bottom: 0.75rem;
+    }
+    .template-options { display: flex; flex-direction: column; gap: 0.5rem; }
+    .template-option {
+      display: flex;
+      align-items: flex-start;
+      padding: 0.75rem 1rem;
+      border: 1px solid var(--cf-border);
+      border-radius: var(--border-radius);
+      cursor: pointer;
+      transition: all 0.15s ease;
+      background: transparent;
+    }
+    .template-option:hover { border-color: var(--cf-border-dark); background: var(--cf-cream); }
+    .template-option.selected {
+      border-color: var(--cf-orange);
+      background: var(--cf-orange-light);
+    }
+    .template-option input[type="radio"] {
+      appearance: none;
+      width: 18px; height: 18px;
+      border: 2px solid var(--cf-border-dark);
+      border-radius: 50%;
+      margin-right: 0.75rem;
+      margin-top: 2px;
+      flex-shrink: 0;
+      position: relative;
+      cursor: pointer;
+      background: white;
+    }
+    .template-option input[type="radio"]:checked {
+      border-color: var(--cf-orange);
+      background: var(--cf-orange);
+    }
+    .template-option input[type="radio"]:checked::after {
+      content: '';
+      position: absolute;
+      top: 50%; left: 50%;
+      transform: translate(-50%, -50%);
+      width: 6px; height: 6px;
+      background: white;
+      border-radius: 50%;
+    }
+    .template-content { flex: 1; }
+    .template-name { font-weight: 500; color: var(--cf-text); font-size: 0.9rem; }
+    .template-desc { font-size: 0.8rem; color: var(--cf-text-muted); margin-top: 0.25rem; line-height: 1.4; }
+    .advanced-toggle {
+      background: none;
+      border: none;
+      color: var(--cf-orange);
+      cursor: pointer;
+      font-size: 0.8rem;
+      font-weight: 500;
+      padding: 0;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4rem;
+      margin-bottom: 1rem;
+    }
+    .advanced-toggle:hover { text-decoration: underline; }
+    .advanced-toggle svg { width: 12px; height: 12px; transition: transform 0.2s ease; }
+    .advanced-toggle.open svg { transform: rotate(90deg); }
+    .advanced-section {
+      display: none;
+      margin-bottom: 1.25rem;
+      animation: fadeIn 0.2s ease;
+    }
+    .advanced-section.open { display: block; }
+    @keyframes fadeIn {
+      from { opacity: 0; transform: translateY(-4px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+    .scope-groups {
+      max-height: 300px;
+      overflow-y: auto;
+      border: 1px solid var(--cf-border);
+      border-radius: var(--border-radius);
+      background: var(--cf-cream);
+    }
+    .scope-groups::-webkit-scrollbar { width: 6px; }
+    .scope-groups::-webkit-scrollbar-track { background: transparent; }
+    .scope-groups::-webkit-scrollbar-thumb { background: var(--cf-border-dark); border-radius: 3px; }
+    .scope-group { padding: 0.5rem; }
+    .scope-group + .scope-group { border-top: 1px solid var(--cf-border); }
+    .scope-group-header {
+      font-size: 0.7rem;
+      font-weight: 600;
+      color: var(--cf-text-muted);
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      padding: 0.5rem;
+      position: sticky;
+      top: 0;
+      background: var(--cf-cream);
+    }
+    .scope-item {
+      display: flex;
+      align-items: center;
+      padding: 0.4rem 0.5rem;
+      cursor: pointer;
+      border-radius: 4px;
+      font-size: 0.8rem;
+    }
+    .scope-item:hover { background: white; }
+    .scope-item input[type="checkbox"] {
+      appearance: none;
+      width: 14px; height: 14px;
+      border: 1px solid var(--cf-border-dark);
+      border-radius: 3px;
+      margin-right: 0.5rem;
+      cursor: pointer;
+      position: relative;
+      flex-shrink: 0;
+      background: white;
+    }
+    .scope-item input[type="checkbox"]:checked {
+      background: var(--cf-orange);
+      border-color: var(--cf-orange);
+    }
+    .scope-item input[type="checkbox"]:checked::after {
+      content: '';
+      position: absolute;
+      top: 1px; left: 4px;
+      width: 4px; height: 8px;
+      border: solid white;
+      border-width: 0 2px 2px 0;
+      transform: rotate(45deg);
+    }
+    .scope-name {
+      font-family: 'SF Mono', Monaco, 'Courier New', monospace;
+      font-size: 0.75rem;
+      color: var(--cf-text);
+      min-width: 140px;
+    }
+    .scope-desc {
+      color: var(--cf-text-light);
+      font-size: 0.75rem;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    .info-text {
+      font-size: 0.8rem;
+      color: var(--cf-text-muted);
+      margin-bottom: 1.25rem;
+      display: flex;
+      align-items: flex-start;
+      gap: 0.5rem;
+    }
+    .info-text svg { width: 16px; height: 16px; flex-shrink: 0; margin-top: 1px; color: var(--cf-text-light); }
+    .actions {
+      display: flex;
+      gap: 0.75rem;
+      padding-top: 1rem;
+      border-top: 1px solid var(--cf-border);
+    }
+    .button {
+      flex: 1;
+      padding: 0.75rem 1.25rem;
+      border-radius: 100px;
+      font-weight: 500;
+      cursor: pointer;
+      border: none;
+      font-size: 0.9rem;
+      font-family: inherit;
+      transition: all 0.15s ease;
+      text-align: center;
+    }
+    .button-primary { background: var(--cf-orange); color: white; }
+    .button-primary:hover { background: var(--cf-orange-hover); transform: translateY(-1px); }
+    .button-secondary {
+      background: transparent;
+      border: 1px solid var(--cf-orange);
+      color: var(--cf-orange);
+    }
+    .button-secondary:hover { background: var(--cf-orange-light); }
+    .footer {
+      padding: 1rem 2rem;
+      text-align: center;
+      font-size: 0.75rem;
+      color: var(--cf-text-light);
+      border-top: 1px solid var(--cf-border);
+      background: white;
+    }
+    .footer a { color: var(--cf-text-muted); text-decoration: none; }
+    .footer a:hover { color: var(--cf-orange); }
+  </style>
+</head>
+<body>
+  <header class="header">
+    <a href="https://cloudflare.com" class="cf-logo">
+      <img src="https://www.cloudflare.com/img/logo-cloudflare-dark.svg" alt="Cloudflare" height="32">
+    </a>
+    <div class="cf-logo-divider"></div>
+    <span class="cf-logo-product">MCP Server</span>
+  </header>
+
+  <main class="main">
+    <div class="card">
+      <div class="card-header">
+        <h1 class="card-title">Upgrade Permissions</h1>
+        <p class="card-subtitle">Add scopes to your current session</p>
+      </div>
+
+      <div class="card-body">
+        <div class="warning">${escapeHtml(state.errorMessage)}</div>
+
+        <form method="post" action="/elicitation/${escapeHtml(agentId)}/upgrade" id="upgradeForm">
+          <div class="scope-section">
+            <div class="scope-label">Quick Select</div>
+            <div class="template-options">
+              ${templateOptionsHtml}
+            </div>
+          </div>
+
+          <button type="button" class="advanced-toggle" id="advancedToggle" onclick="toggleAdvanced()">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round">
+              <path d="M9 18l6-6-6-6"/>
+            </svg>
+            Select individual permissions
+          </button>
+          <div class="advanced-section" id="advancedSection">
+            <div id="scopeCounter" style="font-size: 0.75rem; color: var(--cf-text-muted); margin-bottom: 0.5rem; font-weight: 500;"></div>
+            <div class="scope-groups">
+              ${scopeGroupsHtml}
+            </div>
+          </div>
+
+          <div class="info-text">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <circle cx="12" cy="12" r="10"/>
+              <path d="M12 16v-4M12 8h.01"/>
+            </svg>
+            <span>Your current scopes are pre-selected. Add the permissions you need, then click Continue to authorize via Cloudflare.</span>
+          </div>
+
+          <div class="actions">
+            <button type="button" class="button button-secondary" onclick="window.close()">Cancel</button>
+            <button type="submit" class="button button-primary">Continue</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </main>
+
+  <footer class="footer">
+    <a href="https://cloudflare.com/privacypolicy">Privacy</a> &middot;
+    <a href="https://cloudflare.com/terms">Terms</a> &middot;
+    <a href="https://developers.cloudflare.com">Docs</a>
+  </footer>
+
+  <script>
+    const templates = ${JSON.stringify(Object.fromEntries(Object.entries(SCOPE_TEMPLATES).map(([k, v]) => [k, v.scopes])))};
+    const maxScopes = ${MAX_SCOPES};
+
+    function getCheckedCount() {
+      return document.querySelectorAll('.scope-checkbox:checked').length;
+    }
+
+    function updateScopeCounter() {
+      const counter = document.getElementById('scopeCounter');
+      if (!counter || !maxScopes) return;
+      const count = getCheckedCount();
+      counter.textContent = count + ' / ' + maxScopes + ' scopes selected';
+      counter.style.color = count >= maxScopes ? 'var(--cf-red)' : 'var(--cf-text-muted)';
+    }
+
+    function enforceScopeLimit() {
+      if (!maxScopes) return;
+      const checked = getCheckedCount();
+      document.querySelectorAll('.scope-checkbox').forEach(cb => {
+        if (!cb.checked) {
+          cb.disabled = checked >= maxScopes;
+          cb.closest('.scope-item').style.opacity = checked >= maxScopes ? '0.5' : '1';
+        }
+      });
+      updateScopeCounter();
+    }
+
+    document.querySelectorAll('.scope-checkbox').forEach(cb => {
+      cb.addEventListener('change', enforceScopeLimit);
+    });
+
+    document.querySelectorAll('input[name="scope_template"]').forEach(radio => {
+      radio.addEventListener('change', function() {
+        document.querySelectorAll('.template-option').forEach(opt => opt.classList.remove('selected'));
+        this.closest('.template-option').classList.add('selected');
+        const selectedScopes = templates[this.value] || [];
+        // Merge: keep currently checked, add template scopes
+        const currentlyChecked = new Set(
+          Array.from(document.querySelectorAll('.scope-checkbox:checked')).map(cb => cb.value)
+        );
+        selectedScopes.forEach(s => currentlyChecked.add(s));
+        document.querySelectorAll('.scope-checkbox').forEach(cb => {
+          cb.checked = currentlyChecked.has(cb.value);
+        });
+        enforceScopeLimit();
+      });
+    });
+
+    // Initialize counter
+    enforceScopeLimit();
+
+    function toggleAdvanced() {
+      const section = document.getElementById('advancedSection');
+      const toggle = document.getElementById('advancedToggle');
+      section.classList.toggle('open');
+      toggle.classList.toggle('open');
+    }
+
+    // Start with advanced open since user needs to see their current scopes
+    toggleAdvanced();
+  </script>
+</body>
+</html>`
+}
+
+function renderCompletePage(newScopes: string[]): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Permissions Upgraded | Cloudflare MCP</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --cf-orange: #f6821f;
+      --cf-cream: #fbf8f3;
+      --cf-border: rgba(60, 36, 21, 0.1);
+      --cf-text: #3c2415;
+      --cf-text-muted: #6b5c52;
+      --cf-text-light: #9a8a7c;
+      --cf-green: #00b894;
+      --cf-green-light: rgba(0, 184, 148, 0.08);
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+      line-height: 1.5;
+      color: var(--cf-text);
+      background: var(--cf-cream);
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+    .header {
+      padding: 1rem 2rem;
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      border-bottom: 1px solid var(--cf-border);
+      background: white;
+    }
+    .cf-logo { display: flex; align-items: center; gap: 0.5rem; text-decoration: none; }
+    .cf-logo-divider { width: 1px; height: 24px; background: rgba(60, 36, 21, 0.15); margin: 0 0.5rem; }
+    .cf-logo-product { font-size: 0.9rem; color: var(--cf-text-muted); }
+    .main { flex: 1; display: flex; align-items: center; justify-content: center; padding: 2rem; }
+    .card {
+      background: white;
+      border: 1px solid var(--cf-border);
+      border-radius: 12px;
+      width: 100%;
+      max-width: 440px;
+      box-shadow: 0 4px 24px rgba(60, 36, 21, 0.06);
+      text-align: center;
+      padding: 2.5rem 2rem;
+    }
+    .success-icon {
+      width: 56px; height: 56px;
+      background: var(--cf-green-light);
+      border-radius: 50%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      margin: 0 auto 1.5rem;
+    }
+    .success-icon svg { width: 28px; height: 28px; color: var(--cf-green); }
+    h1 { font-size: 1.25rem; font-weight: 600; margin-bottom: 0.75rem; }
+    p { font-size: 0.95rem; color: var(--cf-text-muted); margin-bottom: 1.5rem; }
+    .button {
+      display: inline-block;
+      padding: 0.75rem 2rem;
+      border-radius: 100px;
+      font-weight: 500;
+      cursor: pointer;
+      border: none;
+      font-size: 0.9rem;
+      font-family: inherit;
+      text-decoration: none;
+      background: var(--cf-orange);
+      color: white;
+      transition: all 0.15s ease;
+    }
+    .button:hover { background: #e5750f; transform: translateY(-1px); }
+    .footer {
+      padding: 1rem 2rem;
+      text-align: center;
+      font-size: 0.75rem;
+      color: var(--cf-text-light);
+      border-top: 1px solid var(--cf-border);
+      background: white;
+    }
+    .footer a { color: var(--cf-text-muted); text-decoration: none; }
+    .footer a:hover { color: var(--cf-orange); }
+  </style>
+</head>
+<body>
+  <header class="header">
+    <a href="https://cloudflare.com" class="cf-logo">
+      <img src="https://www.cloudflare.com/img/logo-cloudflare-dark.svg" alt="Cloudflare" height="32">
+    </a>
+    <div class="cf-logo-divider"></div>
+    <span class="cf-logo-product">MCP Server</span>
+  </header>
+  <main class="main">
+    <div class="card">
+      <div class="success-icon">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+          <polyline points="20 6 9 17 4 12"/>
+        </svg>
+      </div>
+      <h1>Permissions Upgraded</h1>
+      <p>Your token has been upgraded with ${newScopes.length} scopes. You can close this window and retry the operation.</p>
+      <a href="javascript:window.close()" class="button" onclick="window.close(); return false;">Close Window</a>
+    </div>
+  </main>
+  <footer class="footer">
+    <a href="https://cloudflare.com/privacypolicy">Privacy</a> &middot;
+    <a href="https://cloudflare.com/terms">Terms</a> &middot;
+    <a href="https://developers.cloudflare.com">Docs</a>
+  </footer>
+</body>
+</html>`
+}
+
+function renderFailedPage(reason: string): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Upgrade Failed | Cloudflare MCP</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --cf-orange: #f6821f;
+      --cf-cream: #fbf8f3;
+      --cf-border: rgba(60, 36, 21, 0.1);
+      --cf-text: #3c2415;
+      --cf-text-muted: #6b5c52;
+      --cf-text-light: #9a8a7c;
+      --cf-red: #d63031;
+      --cf-red-light: rgba(214, 48, 49, 0.08);
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+      line-height: 1.5;
+      color: var(--cf-text);
+      background: var(--cf-cream);
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+    .header {
+      padding: 1rem 2rem;
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      border-bottom: 1px solid var(--cf-border);
+      background: white;
+    }
+    .cf-logo { display: flex; align-items: center; gap: 0.5rem; text-decoration: none; }
+    .cf-logo-divider { width: 1px; height: 24px; background: rgba(60, 36, 21, 0.15); margin: 0 0.5rem; }
+    .cf-logo-product { font-size: 0.9rem; color: var(--cf-text-muted); }
+    .main { flex: 1; display: flex; align-items: center; justify-content: center; padding: 2rem; }
+    .card {
+      background: white;
+      border: 1px solid var(--cf-border);
+      border-radius: 12px;
+      width: 100%;
+      max-width: 440px;
+      box-shadow: 0 4px 24px rgba(60, 36, 21, 0.06);
+      text-align: center;
+      padding: 2.5rem 2rem;
+    }
+    .error-icon {
+      width: 56px; height: 56px;
+      background: var(--cf-red-light);
+      border-radius: 50%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      margin: 0 auto 1.5rem;
+    }
+    .error-icon svg { width: 28px; height: 28px; color: var(--cf-red); }
+    h1 { font-size: 1.25rem; font-weight: 600; margin-bottom: 0.75rem; }
+    p { font-size: 0.95rem; color: var(--cf-text-muted); margin-bottom: 1.5rem; }
+    .error-details {
+      background: var(--cf-cream);
+      border: 1px solid var(--cf-border);
+      border-radius: 8px;
+      padding: 1rem;
+      font-family: 'SF Mono', Monaco, 'Courier New', monospace;
+      font-size: 0.8rem;
+      color: var(--cf-text-muted);
+      text-align: left;
+      word-break: break-word;
+      margin-bottom: 1.5rem;
+    }
+    .button {
+      display: inline-block;
+      padding: 0.75rem 2rem;
+      border-radius: 100px;
+      font-weight: 500;
+      cursor: pointer;
+      border: none;
+      font-size: 0.9rem;
+      font-family: inherit;
+      text-decoration: none;
+      background: var(--cf-orange);
+      color: white;
+      transition: all 0.15s ease;
+    }
+    .button:hover { background: #e5750f; transform: translateY(-1px); }
+    .footer {
+      padding: 1rem 2rem;
+      text-align: center;
+      font-size: 0.75rem;
+      color: var(--cf-text-light);
+      border-top: 1px solid var(--cf-border);
+      background: white;
+    }
+    .footer a { color: var(--cf-text-muted); text-decoration: none; }
+    .footer a:hover { color: var(--cf-orange); }
+  </style>
+</head>
+<body>
+  <header class="header">
+    <a href="https://cloudflare.com" class="cf-logo">
+      <img src="https://www.cloudflare.com/img/logo-cloudflare-dark.svg" alt="Cloudflare" height="32">
+    </a>
+    <div class="cf-logo-divider"></div>
+    <span class="cf-logo-product">MCP Server</span>
+  </header>
+  <main class="main">
+    <div class="card">
+      <div class="error-icon">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <circle cx="12" cy="12" r="10"/>
+          <line x1="15" y1="9" x2="9" y2="15"/>
+          <line x1="9" y1="9" x2="15" y2="15"/>
+        </svg>
+      </div>
+      <h1>Upgrade Failed</h1>
+      <p>The permission upgrade could not be completed.</p>
+      <div class="error-details">${escapeHtml(reason)}</div>
+      <a href="javascript:window.close()" class="button" onclick="window.close(); return false;">Close Window</a>
+    </div>
+  </main>
+  <footer class="footer">
+    <a href="https://cloudflare.com/privacypolicy">Privacy</a> &middot;
+    <a href="https://cloudflare.com/terms">Terms</a> &middot;
+    <a href="https://developers.cloudflare.com">Docs</a>
+  </footer>
+</body>
+</html>`
+}

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -1,5 +1,5 @@
 interface CodeExecutorEntrypoint {
-  evaluate(): Promise<{ result: unknown; err?: string; stack?: string }>
+  evaluate(): Promise<{ result: unknown; err?: string; stack?: string; httpStatus?: number }>
 }
 
 interface SearchExecutorEntrypoint {
@@ -65,7 +65,9 @@ export default class CodeExecutor extends WorkerEntrypoint {
         if (!responseContentType.includes("application/json")) {
           const text = await response.text();
           if (!response.ok) {
-            throw new Error("Cloudflare API error: " + response.status + " " + text);
+            const err = new Error("Cloudflare API error: " + response.status + " " + text);
+            err.httpStatus = response.status;
+            throw err;
           }
           return { success: true, status: response.status, result: text };
         }
@@ -83,7 +85,9 @@ export default class CodeExecutor extends WorkerEntrypoint {
           // Complete failure: no data, only errors
           if (graphqlErrors.length > 0 && !hasData) {
             const msgs = graphqlErrors.map(e => e.message).join(", ");
-            throw new Error("GraphQL error: " + msgs);
+            const err = new Error("GraphQL error: " + msgs);
+            err.httpStatus = response.status;
+            throw err;
           }
 
           // Success or partial success
@@ -105,7 +109,9 @@ export default class CodeExecutor extends WorkerEntrypoint {
         // Handle REST API responses
         if (!data.success) {
           const errors = data.errors.map(e => e.code + ": " + e.message).join(", ");
-          throw new Error("Cloudflare API error: " + errors);
+          const err = new Error("Cloudflare API error: " + errors);
+          err.httpStatus = response.status;
+          throw err;
         }
 
         return { ...data, status: response.status };
@@ -116,7 +122,8 @@ export default class CodeExecutor extends WorkerEntrypoint {
       const result = await (${code})();
       return { result, err: undefined };
     } catch (err) {
-      return { result: undefined, err: err.message, stack: err.stack };
+      const httpStatus = (typeof err === 'object' && err !== null) ? err.httpStatus : undefined;
+      return { result: undefined, err: err.message, stack: err.stack, httpStatus };
     }
   }
 }
@@ -128,7 +135,11 @@ export default class CodeExecutor extends WorkerEntrypoint {
     const response = await entrypoint.evaluate()
 
     if (response.err) {
-      throw new Error(response.err)
+      const error = new Error(response.err)
+      if (response.httpStatus !== undefined) {
+        ;(error as any).httpStatus = response.httpStatus
+      }
+      throw error
     }
 
     return response.result

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,15 @@
 import OAuthProvider from '@cloudflare/workers-oauth-provider'
 import { Hono } from 'hono'
 import { WorkerEntrypoint } from 'cloudflare:workers'
+import { getAgentByName } from 'agents'
 import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js'
 import { createServer } from './server'
 import { createAuthHandlers, handleTokenExchangeCallback } from './auth/oauth-handler'
 import { isDirectApiToken, handleApiTokenRequest } from './auth/api-token-mode'
 import { processSpec, extractProducts } from './spec-processor'
 import type { AuthProps } from './auth/types'
+
+export { ElicitationAgent } from './elicitation-agent'
 
 /**
  * Global outbound fetch handler that restricts dynamically-loaded workers
@@ -48,7 +51,8 @@ async function createMcpResponse(
   accountId?: string,
   props?: AuthProps
 ): Promise<Response> {
-  const server = await createServer(env, ctx, token, accountId, props)
+  const baseUrl = new URL(request.url).origin
+  const server = await createServer(env, ctx, token, accountId, props, baseUrl)
   const transport = new WebStandardStreamableHTTPServerTransport({
     sessionIdGenerator: undefined,
     enableJsonResponse: true,
@@ -87,6 +91,20 @@ function createMcpHandler() {
 
 export default {
   async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+    // Route /elicitation/:id[/action] to ElicitationAgent DO (browser callback, no auth needed)
+    const url = new URL(request.url)
+    if (url.pathname.startsWith('/elicitation/')) {
+      const rest = url.pathname.slice('/elicitation/'.length)
+      const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i
+      const match = rest.match(uuidRegex)
+      if (!match) {
+        return new Response('Bad Request: invalid elicitation ID', { status: 400 })
+      }
+      const id = match[0]
+      const stub = await getAgentByName(env.ELICITATION_AGENT, id)
+      return stub.fetch(request)
+    }
+
     // Check for direct API token first (like GitHub MCP's PAT support)
     if (isDirectApiToken(request)) {
       const response = await handleApiTokenRequest(request, (token, accountId, props) =>

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,4 +1,6 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { UrlElicitationRequiredError } from '@modelcontextprotocol/sdk/types.js'
+import { getAgentByName } from 'agents'
 import { z } from 'zod'
 import { createCodeExecutor, createSearchExecutor } from './executor'
 import { truncateResponse } from './truncate'
@@ -40,6 +42,115 @@ function formatError(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
 }
 
+const SCOPES_DOCS_URL = 'https://developers.cloudflare.com/fundamentals/api/reference/permissions/'
+
+const ELICITATION_MESSAGE =
+  'This API call requires additional permissions. ' +
+  'Open the link below to upgrade your scopes, then retry the operation.'
+
+type ToolResult = { content: { type: 'text'; text: string }[]; isError: true }
+
+/**
+ * Compute a SHA-256 hash of the API token for use as a KV key.
+ * This avoids storing the raw token in agent state.
+ */
+async function hashToken(token: string): Promise<string> {
+  const buffer = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(token))
+  return Array.from(new Uint8Array(buffer))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+}
+
+/**
+ * Check KV for a scope-upgraded token. Returns the upgraded token if available.
+ */
+async function getUpgradedToken(
+  env: Env,
+  tokenHash: string
+): Promise<string | null> {
+  const data = await env.OAUTH_KV.get(`token-upgrade:${tokenHash}`, 'json') as {
+    accessToken: string
+    refreshToken: string
+    scopes: string[]
+    timestamp: number
+  } | null
+
+  return data?.accessToken ?? null
+}
+
+interface ElicitationContext {
+  server: McpServer
+  env: Env
+  baseUrl: string
+  currentScopes?: string[]
+  tokenHash: string
+  userId?: string
+}
+
+/**
+ * Handle 403 (insufficient scope) errors from the Cloudflare API.
+ *
+ * Creates an ElicitationAgent with a scope picker UI so the user can
+ * upgrade their permissions without a full re-auth.
+ *
+ * - If the client supports URL elicitation: throws UrlElicitationRequiredError
+ * - If the client does NOT support elicitation: returns a tool error result
+ *   containing the scope upgrade URL
+ * - If not a 403: returns undefined (caller should handle normally)
+ */
+export async function elicitUpdatedScopes(
+  error: unknown,
+  ctx?: ElicitationContext
+): Promise<ToolResult | undefined> {
+  if (!(error instanceof Error)) return undefined
+  const status = (error as any).httpStatus
+  if (status !== 403) return undefined
+
+  const elicitationId = crypto.randomUUID()
+  let callbackUrl = SCOPES_DOCS_URL
+
+  // Create an ElicitationAgent with scope picker if the binding is available
+  if (ctx?.env.ELICITATION_AGENT) {
+    try {
+      const stub = await getAgentByName(ctx.env.ELICITATION_AGENT, elicitationId)
+      await stub.fetch(new Request('https://agent/init', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          errorMessage: error.message,
+          currentScopes: ctx.currentScopes || [],
+          tokenHash: ctx.tokenHash,
+          userId: ctx.userId || 'unknown'
+        })
+      }))
+      callbackUrl = `${ctx.baseUrl}/elicitation/${elicitationId}`
+    } catch {
+      // Fall back to static docs URL if agent creation fails
+    }
+  }
+
+  const message = `${ELICITATION_MESSAGE}\n\n(${error.message})`
+
+  // Check if the client supports URL elicitation
+  const capabilities = ctx?.server.server.getClientCapabilities()
+  if (capabilities?.elicitation?.url) {
+    throw new UrlElicitationRequiredError([
+      {
+        mode: 'url',
+        message,
+        url: callbackUrl,
+        elicitationId
+      }
+    ])
+  }
+
+  // Client does NOT support elicitation — return URL in tool error result
+  return {
+    content: [{ type: 'text', text: `${message}\n\nUpgrade permissions here: ${callbackUrl}` }],
+    isError: true
+  }
+}
+
 const SPEC_TYPES = `
 interface OperationInfo {
   summary?: string;
@@ -68,7 +179,8 @@ export async function createServer(
   ctx: ExecutionContext,
   apiToken: string,
   accountId: string | undefined,
-  props?: AuthProps
+  props?: AuthProps,
+  baseUrl?: string
 ): Promise<McpServer> {
   const server = new McpServer({
     name: 'cloudflare-api',
@@ -77,6 +189,13 @@ export async function createServer(
 
   const executeCode = createCodeExecutor(env, ctx)
   const executeSearch = createSearchExecutor(env)
+
+  // Pre-compute token hash for scope upgrade lookups
+  const tokenHash = await hashToken(apiToken)
+
+  // Extract user context for elicitation
+  const currentScopes = props?.type === 'user_token' ? props.scopes : undefined
+  const userId = props?.type === 'user_token' ? props.user.id : undefined
 
   const obj = await env.SPEC_BUCKET.get('products.json')
   const products: string[] = obj ? await obj.json() : []
@@ -162,9 +281,16 @@ async () => {
       },
       async ({ code }) => {
         try {
-          const result = await executeCode(code, accountId, apiToken)
+          // Check for scope-upgraded token
+          const effectiveToken = await getUpgradedToken(env, tokenHash) || apiToken
+          const result = await executeCode(code, accountId, effectiveToken)
           return { content: [{ type: 'text', text: truncateResponse(result) }] }
         } catch (error) {
+          const elicitation = await elicitUpdatedScopes(
+            error,
+            baseUrl ? { server, env, baseUrl, currentScopes, tokenHash, userId } : undefined
+          )
+          if (elicitation) return elicitation
           return {
             content: [{ type: 'text', text: `Error: ${formatError(error)}` }],
             isError: true
@@ -219,9 +345,16 @@ async () => {
             }
           }
 
-          const result = await executeCode(code, effectiveAccountId, apiToken)
+          // Check for scope-upgraded token
+          const effectiveToken = await getUpgradedToken(env, tokenHash) || apiToken
+          const result = await executeCode(code, effectiveAccountId, effectiveToken)
           return { content: [{ type: 'text', text: truncateResponse(result) }] }
         } catch (error) {
+          const elicitation = await elicitUpdatedScopes(
+            error,
+            baseUrl ? { server, env, baseUrl, currentScopes, tokenHash, userId } : undefined
+          )
+          if (elicitation) return elicitation
           return {
             content: [{ type: 'text', text: `Error: ${formatError(error)}` }],
             isError: true

--- a/src/tests/jit-auth.test.ts
+++ b/src/tests/jit-auth.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createCodeExecutor } from '../executor'
+import { elicitUpdatedScopes } from '../server'
+
+describe('JIT Auth - HTTP Status Propagation', () => {
+  let mockEnv: Env
+  let mockCtx: any
+  let mockWorker: any
+  let mockEntrypoint: any
+
+  beforeEach(() => {
+    mockEntrypoint = {
+      evaluate: vi.fn()
+    }
+
+    mockWorker = {
+      getEntrypoint: vi.fn(() => mockEntrypoint)
+    }
+
+    mockEnv = {
+      CLOUDFLARE_API_BASE: 'https://api.cloudflare.com/client/v4',
+      LOADER: {
+        get: vi.fn(() => mockWorker)
+      }
+    } as any
+
+    mockCtx = {
+      exports: {
+        GlobalOutbound: vi.fn(() => ({ fetch: vi.fn() }))
+      }
+    } as any
+  })
+
+  describe('Executor httpStatus propagation', () => {
+    it('should include httpStatus in worker code error handling', async () => {
+      mockEntrypoint.evaluate.mockResolvedValue({ result: {}, err: undefined })
+      const executor = createCodeExecutor(mockEnv, mockCtx)
+      await executor('async () => { return {} }', 'test-account', 'test-token')
+
+      const loaderCall = mockEnv.LOADER.get as any
+      const workerConfig = loaderCall.mock.calls[0][1]()
+      const workerCode = workerConfig.modules['worker.js']
+
+      expect(workerCode).toContain('err.httpStatus = response.status')
+      expect(workerCode).toContain('err.httpStatus')
+    })
+
+    it('should propagate httpStatus 403 from sandbox response to thrown error', async () => {
+      mockEntrypoint.evaluate.mockResolvedValue({
+        result: undefined,
+        err: 'Cloudflare API error: 10000: Authentication error',
+        stack: 'Error: ...',
+        httpStatus: 403
+      })
+
+      const executor = createCodeExecutor(mockEnv, mockCtx)
+
+      try {
+        await executor('async () => {}', 'test-account', 'test-token')
+        expect.unreachable('should have thrown')
+      } catch (error: any) {
+        expect(error).toBeInstanceOf(Error)
+        expect(error.message).toBe('Cloudflare API error: 10000: Authentication error')
+        expect(error.httpStatus).toBe(403)
+      }
+    })
+
+    it('should propagate httpStatus 500 from sandbox', async () => {
+      mockEntrypoint.evaluate.mockResolvedValue({
+        result: undefined,
+        err: 'Cloudflare API error: Internal Server Error',
+        stack: 'Error: ...',
+        httpStatus: 500
+      })
+
+      const executor = createCodeExecutor(mockEnv, mockCtx)
+
+      try {
+        await executor('async () => {}', 'test-account', 'test-token')
+        expect.unreachable('should have thrown')
+      } catch (error: any) {
+        expect(error).toBeInstanceOf(Error)
+        expect(error.httpStatus).toBe(500)
+      }
+    })
+
+    it('should not set httpStatus when sandbox error has no status', async () => {
+      mockEntrypoint.evaluate.mockResolvedValue({
+        result: undefined,
+        err: 'User code threw an error',
+        stack: 'Error: ...'
+      })
+
+      const executor = createCodeExecutor(mockEnv, mockCtx)
+
+      try {
+        await executor('async () => {}', 'test-account', 'test-token')
+        expect.unreachable('should have thrown')
+      } catch (error: any) {
+        expect(error).toBeInstanceOf(Error)
+        expect(error.message).toBe('User code threw an error')
+        expect(error.httpStatus).toBeUndefined()
+      }
+    })
+  })
+})
+
+describe('JIT Auth - elicitUpdatedScopes', () => {
+  it('should return tool error with URL for 403 errors (no ctx)', async () => {
+    const error = new Error('Cloudflare API error: 10000: Authentication error')
+    ;(error as any).httpStatus = 403
+
+    const result = await elicitUpdatedScopes(error)
+    expect(result).toBeDefined()
+    expect(result!.isError).toBe(true)
+    expect(result!.content[0].text).toContain('10000: Authentication error')
+    expect(result!.content[0].text).toContain(
+      'https://developers.cloudflare.com/fundamentals/api/reference/permissions/'
+    )
+  })
+
+  it('should include re-authorize URL in the tool error message', async () => {
+    const error = new Error('Cloudflare API error: 10000: Authentication error')
+    ;(error as any).httpStatus = 403
+
+    const result = await elicitUpdatedScopes(error)
+    expect(result!.content[0].text).toContain('Upgrade permissions here:')
+  })
+
+  it('should return undefined for non-403 errors', async () => {
+    const error = new Error('Cloudflare API error: Internal Server Error')
+    ;(error as any).httpStatus = 500
+
+    const result = await elicitUpdatedScopes(error)
+    expect(result).toBeUndefined()
+  })
+
+  it('should return undefined for errors without httpStatus', async () => {
+    const error = new Error('some user error')
+
+    const result = await elicitUpdatedScopes(error)
+    expect(result).toBeUndefined()
+  })
+
+  it('should return undefined for non-Error values', async () => {
+    expect(await elicitUpdatedScopes('some string error')).toBeUndefined()
+    expect(await elicitUpdatedScopes(42)).toBeUndefined()
+    expect(await elicitUpdatedScopes(null)).toBeUndefined()
+    expect(await elicitUpdatedScopes(undefined)).toBeUndefined()
+  })
+})

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -9,6 +9,7 @@ declare namespace Cloudflare {
 		OAUTH_KV: KVNamespace;
 		SPEC_BUCKET: R2Bucket;
 		LOADER: WorkerLoader;
+		ELICITATION_AGENT: DurableObjectNamespace<import("./src/elicitation-agent").ElicitationAgent>;
 		CLOUDFLARE_API_BASE: "https://api.cloudflare.com/client/v4";
 		OPENAPI_SPEC_URL: "https://raw.githubusercontent.com/cloudflare/api-schemas/main/openapi.json";
 		MCP_COOKIE_ENCRYPTION_KEY: string;
@@ -21,6 +22,7 @@ declare namespace Cloudflare {
 		OAUTH_KV: KVNamespace;
 		SPEC_BUCKET: R2Bucket;
 		LOADER: WorkerLoader;
+		ELICITATION_AGENT: DurableObjectNamespace<import("./src/elicitation-agent").ElicitationAgent>;
 		CLOUDFLARE_API_BASE: "https://api.cloudflare.com/client/v4";
 		OPENAPI_SPEC_URL: "https://raw.githubusercontent.com/cloudflare/api-schemas/main/openapi.json";
 		MCP_COOKIE_ENCRYPTION_KEY: string;
@@ -37,6 +39,7 @@ declare namespace Cloudflare {
 		OAUTH_KV: KVNamespace;
 		SPEC_BUCKET: R2Bucket;
 		LOADER: WorkerLoader;
+		ELICITATION_AGENT: DurableObjectNamespace<import("./src/elicitation-agent").ElicitationAgent>;
 		CLOUDFLARE_API_BASE: "https://api.cloudflare.com/client/v4";
 		OPENAPI_SPEC_URL: "https://raw.githubusercontent.com/cloudflare/api-schemas/main/openapi.json";
 		GLOBAL_OUTBOUND: Service /* entrypoint GlobalOutbound from cloudflare-api-mcp-staging */ | Service /* entrypoint GlobalOutbound from cloudflare-api-mcp */ | Service<typeof import("./src/index").GlobalOutbound>;

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -42,6 +42,20 @@
 			"bucket_name": "mcp-spec"
 		}
 	],
+	"durable_objects": {
+		"bindings": [
+			{
+				"name": "ELICITATION_AGENT",
+				"class_name": "ElicitationAgent"
+			}
+		]
+	},
+	"migrations": [
+		{
+			"tag": "v1",
+			"new_sqlite_classes": ["ElicitationAgent"]
+		}
+	],
 	"triggers": {
 		"crons": ["0 0 * * *"]
 	},
@@ -79,6 +93,20 @@
 				{
 					"binding": "SPEC_BUCKET",
 					"bucket_name": "mcp-spec-staging"
+				}
+			],
+			"durable_objects": {
+				"bindings": [
+					{
+						"name": "ELICITATION_AGENT",
+						"class_name": "ElicitationAgent"
+					}
+				]
+			},
+			"migrations": [
+				{
+					"tag": "v1",
+					"new_sqlite_classes": ["ElicitationAgent"]
 				}
 			],
 			"triggers": {
@@ -119,6 +147,20 @@
 				{
 					"binding": "SPEC_BUCKET",
 					"bucket_name": "mcp-spec-production"
+				}
+			],
+			"durable_objects": {
+				"bindings": [
+					{
+						"name": "ELICITATION_AGENT",
+						"class_name": "ElicitationAgent"
+					}
+				]
+			},
+			"migrations": [
+				{
+					"tag": "v1",
+					"new_sqlite_classes": ["ElicitationAgent"]
 				}
 			],
 			"triggers": {


### PR DESCRIPTION
## Summary

- When the `execute` tool hits a **403** from the Cloudflare API, creates an **ElicitationAgent** (Durable Object via Agents SDK) that serves a scope picker UI
- The scope picker matches the Cloudflare design system and shows current scopes pre-checked so the user can add what they need
- After selecting scopes, the user is redirected through Cloudflare OAuth to get a new token — **no full MCP reconnection required**
- The upgraded token is stored in KV and automatically picked up by subsequent `execute` calls

### How it works

1. `execute` tool catches 403 → `elicitUpdatedScopes()` creates ElicitationAgent with error context + current scopes
2. User opens the elicitation URL → sees scope picker with templates (Read Only, Workers Full, DNS Full) + individual checkboxes
3. User adds scopes, clicks Continue → redirected to Cloudflare OAuth
4. `/oauth/callback` detects `scope_upgrade` state → exchanges code → stores upgraded token in `OAUTH_KV` as `token-upgrade:{tokenHash}`
5. Next `execute` call → `getUpgradedToken()` finds the upgrade in KV → uses the new token transparently

### Changes

| File | Change |
|------|--------|
| `src/elicitation-agent.ts` | **New** — ElicitationAgent with scope picker UI, OAuth redirect, token storage |
| `src/server.ts` | `elicitUpdatedScopes()` passes scopes/tokenHash/userId to agent; execute handler checks KV for upgrades |
| `src/auth/oauth-handler.ts` | Stores scopes in props; `/oauth/callback` handles `scope_upgrade` flow |
| `src/auth/types.ts` | Added `scopes?: string[]` to `UserAuthProps` |
| `src/executor.ts` | HTTP status propagation from sandbox worker errors (`httpStatus` field) |
| `src/index.ts` | Exports ElicitationAgent; routes `/elicitation/:id[/action]` to DO |
| `wrangler.jsonc` | DO binding + migration for ElicitationAgent (all envs) |
| `worker-configuration.d.ts` | `ELICITATION_AGENT` binding type |
| `src/tests/jit-auth.test.ts` | **New** — tests for httpStatus propagation and elicitUpdatedScopes |

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm test` — 92 tests pass
- [x] Deployed to staging (`staging.mcp.cloudflare.com`)
- [x] Triggered 403 via `execute` → elicitation URL returned
- [x] Opened elicitation URL → scope picker renders correctly
- [x] Selected "Workers Full Access" template → 21 scopes checked
- [x] Clicked Continue → redirected to Cloudflare OAuth login