### PR TITLE
Add endpoint pattern examples to execute tool description

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -141,6 +141,18 @@ ${CLOUDFLARE_TYPES}
 
 Your code must be an async arrow function that returns the result.
 
+IMPORTANT: Always use the 'search' tool first to find the correct endpoint path and parameters. Not all endpoints follow the same pattern — some are top-level (e.g. /zones, /user) with query filters, others are nested under /accounts/{account_id}/.
+
+Example: List zones (top-level endpoint with account filter):
+async () => {
+  return cloudflare.request({ method: "GET", path: "/zones", query: { "account.id": accountId } });
+}
+
+Example: List Workers scripts (account-scoped endpoint):
+async () => {
+  return cloudflare.request({ method: "GET", path: \`/accounts/\${accountId}/workers/scripts\` });
+}
+
 Example: Worker with bindings (requires multipart/form-data):
 async () => {
   const code = \`addEventListener('fetch', e => e.respondWith(MY_KV.get('key').then(v => new Response(v || 'none'))));\`;


### PR DESCRIPTION
## Summary
- Adds guidance that not all Cloudflare API endpoints follow the same pattern — some are top-level (e.g. `/zones`, `/user`) with query filters, others are nested under `/accounts/{account_id}/`
- Adds two concrete examples: listing zones (top-level with `account.id` query filter) and listing Workers scripts (account-scoped)
- Adds a note to always use the `search` tool first to find the correct endpoint path

## Context
Another MCP client was hitting errors by using `/accounts/{id}/zones` instead of `/zones?account.id={id}`. These examples should help models pick the right pattern.

## Test plan
- [ ] Verify examples render correctly in tool description
- [ ] Test that `/zones` with query filter works
- [ ] Test that `/accounts/{accountId}/workers/scripts` works