### PR TITLE
Fix bonk workflow

### DIFF
--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -6,22 +6,38 @@ on:
   pull_request_review_comment:
     types: [created]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
+  cancel-in-progress: false
+
 jobs:
   bonk:
-    if: github.event.sender.type != 'Bot' && (contains(github.event.comment.body, '/bonk') || contains(github.event.comment.body, '@ask-bonk'))
+    if: >-
+      github.event.sender.type != 'Bot' &&
+      (contains(github.event.comment.body, '/bonk') || contains(github.event.comment.body, '@ask-bonk')) &&
+      (
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR' ||
+        github.event.comment.author_association == 'OWNER'
+      )
     runs-on: ubuntu-latest
-    timeout-minutes: 20
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-      cancel-in-progress: false
+    timeout-minutes: 30
     permissions:
       id-token: write
+      contents: write
       issues: write
       pull-requests: write
-      contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 30
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
 
       - name: Run Bonk
         uses: ask-bonk/ask-bonk/github@main
@@ -30,5 +46,7 @@ jobs:
           CLOUDFLARE_GATEWAY_ID: ${{ secrets.CF_AI_GATEWAY_NAME }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
         with:
-          model: 'cloudflare-ai-gateway/anthropic/claude-opus-4-6'
-          mentions: '/bonk,@ask-bonk'
+          model: "cloudflare-ai-gateway/anthropic/claude-opus-4-6"
+          mentions: "/bonk,@ask-bonk"
+          permissions: write
+          opencode_dev: false

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -33,11 +33,14 @@ jobs:
         with:
           fetch-depth: 30
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        run: npm ci
 
       - name: Run Bonk
         uses: ask-bonk/ask-bonk/github@main


### PR DESCRIPTION
## Summary
- Fix `ProviderModelNotFoundError` by adding `opencode_dev: false` and `permissions: write` to bonk action config
- Add `author_association` check so only MEMBER/COLLABORATOR/OWNER can trigger bonk
- Add bun setup and dependency install steps (matching vinext pattern)
- Fix concurrency group to include `issue.number`

## Context
Bonk was failing with `ProviderModelNotFoundError` on every trigger. Aligned workflow with the working config from [cloudflare/vinext](https://github.com/cloudflare/vinext/blob/main/.github/workflows/bonk.yml).

## Test plan
- [ ] Comment `/bonk` on an issue or PR to verify it runs successfully