### PR TITLE
docs: add Claude Code connection guide with type:http

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Just connect to the MCP server URL - you'll be redirected to Cloudflare to autho
 }
 ```
 
+> **Claude Code users:** You must add `"type": "http"` to the config. See the [Claude Code connection guide](docs/connection-guides/claude-code.md) for full instructions.
+
 ### Option 2: API Token
 
 For CI/CD, automation, or if you prefer managing tokens yourself.
@@ -188,6 +190,12 @@ execute({
   account_id: "your-account-id",
 });
 ```
+
+## Connection Guides
+
+Client-specific setup instructions:
+
+- [Claude Code](docs/connection-guides/claude-code.md)
 
 ## Build a Code Mode MCP Server
 

--- a/docs/connection-guides/claude-code.md
+++ b/docs/connection-guides/claude-code.md
@@ -1,0 +1,40 @@
+# Connecting with Claude Code
+
+## Configuration
+
+Add the following to your `.mcp.json` file (located in your project root or `~/.claude/.mcp.json` for global config):
+
+```json
+{
+  "mcpServers": {
+    "cloudflare-api": {
+      "type": "http",
+      "url": "https://mcp.cloudflare.com/mcp"
+    }
+  }
+}
+```
+
+> **Important:** The `"type": "http"` field is required. Without it, Claude Code defaults to `stdio` transport and the connection will fail.
+
+## Using an API Token
+
+If you prefer using an API token instead of OAuth, add the `Authorization` header:
+
+```json
+{
+  "mcpServers": {
+    "cloudflare-api": {
+      "type": "http",
+      "url": "https://mcp.cloudflare.com/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_CLOUDFLARE_API_TOKEN"
+      }
+    }
+  }
+}
+```
+
+## Verify the Connection
+
+After saving `.mcp.json`, restart Claude Code. You can verify the server is connected by asking Claude to list your Cloudflare Workers or any other Cloudflare resource.

--- a/docs/connection-guides/claude-code.md
+++ b/docs/connection-guides/claude-code.md
@@ -1,6 +1,25 @@
 # Connecting with Claude Code
 
-## Configuration
+Claude Code supports two ways to add an MCP server.
+
+## Option 1: CLI (recommended)
+
+The quickest way to connect is the `claude mcp add` command:
+
+```bash
+claude mcp add --transport http cloudflare-api https://mcp.cloudflare.com/mcp
+```
+
+To connect with an API token instead of OAuth:
+
+```bash
+claude mcp add --transport http cloudflare-api https://mcp.cloudflare.com/mcp \
+  --header "Authorization: Bearer YOUR_CLOUDFLARE_API_TOKEN"
+```
+
+This writes the configuration to your active `.mcp.json` automatically.
+
+## Option 2: Manual JSON configuration
 
 Add the following to your `.mcp.json` file (located in your project root or `~/.claude/.mcp.json` for global config):
 
@@ -17,9 +36,7 @@ Add the following to your `.mcp.json` file (located in your project root or `~/.
 
 > **Important:** The `"type": "http"` field is required. Without it, Claude Code defaults to `stdio` transport and the connection will fail.
 
-## Using an API Token
-
-If you prefer using an API token instead of OAuth, add the `Authorization` header:
+To use an API token instead of OAuth, add the `Authorization` header:
 
 ```json
 {
@@ -37,4 +54,4 @@ If you prefer using an API token instead of OAuth, add the `Authorization` heade
 
 ## Verify the Connection
 
-After saving `.mcp.json`, restart Claude Code. You can verify the server is connected by asking Claude to list your Cloudflare Workers or any other Cloudflare resource.
+After connecting, restart Claude Code. You can verify the server is connected by asking Claude to list your Cloudflare Workers or any other Cloudflare resource.


### PR DESCRIPTION
## Summary

Adds a Claude Code connection guide to help users configure `.mcp.json` correctly.

**Changes:**
- New `docs/connection-guides/claude-code.md` with full setup instructions
- README.md updated with a note for Claude Code users pointing to the guide
- New "Connection Guides" section in README for client-specific docs

The key issue: Claude Code requires `"type": "http"` in the MCP server config — without it, it defaults to `stdio` transport and the connection silently fails.

Follows the maintainer's suggested structure (`docs/connection-guides/`) from the issue comments.

Fixes #39