### PR TITLE
chore: bump @cloudflare/workers-oauth-provider to ^0.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "cloudflare-mcp",
       "version": "0.1.0",
       "dependencies": {
-        "@cloudflare/workers-oauth-provider": "^0.3.2",
+        "@cloudflare/workers-oauth-provider": "0.3.3",
         "@modelcontextprotocol/sdk": "^1.26.0",
         "hono": "^4.12.7",
         "zod": "^4.3.5"
@@ -154,9 +154,9 @@
       }
     },
     "node_modules/@cloudflare/workers-oauth-provider": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-oauth-provider/-/workers-oauth-provider-0.3.2.tgz",
-      "integrity": "sha512-WFK95ThKutKDiTCPPbfzya1Fo7YMmEISQ0OlmJ+mGQJdb2dwOPS+YUY9Lk9pF/huOB0PS0V2cdb6BESqBlx3cQ==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-oauth-provider/-/workers-oauth-provider-0.3.3.tgz",
+      "integrity": "sha512-n0PrX+KZNdyXx2x6EFfIZKWj254LtiWZTCLcrOVHO4MeoFcGtYyG0a1fD/H365XGlpsCScOVCAS/Pc4JymqKJQ==",
       "license": "MIT"
     },
     "node_modules/@cspotcode/source-map-support": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "cloudflare-mcp",
       "version": "0.1.0",
       "dependencies": {
-        "@cloudflare/workers-oauth-provider": "^0.3.3",
+        "@cloudflare/workers-oauth-provider": "^0.4.0",
         "@modelcontextprotocol/sdk": "^1.26.0",
         "hono": "^4.12.7",
         "zod": "^4.3.5"
@@ -154,9 +154,9 @@
       }
     },
     "node_modules/@cloudflare/workers-oauth-provider": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-oauth-provider/-/workers-oauth-provider-0.3.3.tgz",
-      "integrity": "sha512-n0PrX+KZNdyXx2x6EFfIZKWj254LtiWZTCLcrOVHO4MeoFcGtYyG0a1fD/H365XGlpsCScOVCAS/Pc4JymqKJQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-oauth-provider/-/workers-oauth-provider-0.4.0.tgz",
+      "integrity": "sha512-UtbV8hjC2NloB+Ds6J6v/9HiG8rx8MbdeYGCyFwOACT5vANWzDL6SKo3W5UZymsXiameAgC7jAmtUx4cc+Qpaw==",
       "license": "MIT"
     },
     "node_modules/@cspotcode/source-map-support": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "cloudflare-mcp",
       "version": "0.1.0",
       "dependencies": {
-        "@cloudflare/workers-oauth-provider": "0.3.3",
+        "@cloudflare/workers-oauth-provider": "^0.3.3",
         "@modelcontextprotocol/sdk": "^1.26.0",
         "hono": "^4.12.7",
         "zod": "^4.3.5"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "seed:prod": "tsx scripts/seed-r2.ts production"
   },
   "dependencies": {
-    "@cloudflare/workers-oauth-provider": "^0.3.2",
+    "@cloudflare/workers-oauth-provider": "0.3.3",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "hono": "^4.12.7",
     "zod": "^4.3.5"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "seed:prod": "tsx scripts/seed-r2.ts production"
   },
   "dependencies": {
-    "@cloudflare/workers-oauth-provider": "0.3.3",
+    "@cloudflare/workers-oauth-provider": "^0.3.3",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "hono": "^4.12.7",
     "zod": "^4.3.5"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "seed:prod": "tsx scripts/seed-r2.ts production"
   },
   "dependencies": {
-    "@cloudflare/workers-oauth-provider": "^0.3.3",
+    "@cloudflare/workers-oauth-provider": "^0.4.0",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "hono": "^4.12.7",
     "zod": "^4.3.5"

--- a/src/index.ts
+++ b/src/index.ts
@@ -117,7 +117,10 @@ export default {
       resourceMetadata: {
         resource_name: 'Cloudflare API MCP Server'
       },
-      accessTokenTTL: 3600
+      accessTokenTTL: 3600,
+      refreshTokenTTL: 2592000, // 30 days
+      // TODO: Remove after 2026-05-01 — all pre-0.4.0 grants will have expired by then
+      resourceMatchOriginOnly: true
     }).fetch(request, env, ctx)
   },
 


### PR DESCRIPTION
## Summary
- Bumps `@cloudflare/workers-oauth-provider` from `^0.3.0` to `^0.4.0`
- v0.4.0 adds path-aware resource URIs (RFC 9728 §3.1, §5.1) and a `resourceMatchOriginOnly` migration flag

## Test plan
- [x] Tested on staging (`staging.mcp.cloudflare.com`)
- [x] Verified existing tokens work after upgrade
- [x] Verified `resourceMatchOriginOnly` flag enables seamless migration for origin-only grants
- [ ] CI passes