### PR TITLE
feat: add email_routing:write and email_sending:write scopes

### DIFF
--- a/src/auth/scopes.ts
+++ b/src/auth/scopes.ts
@@ -120,6 +120,10 @@ export const ALL_SCOPES = {
   'mcp_portals:read': 'View MCP Portal configurations',
   'mcp_portals:write': 'Create and modify MCP Portals',
 
+  // Email
+  'email_routing:write': 'Configure email routing rules',
+  'email_sending:write': 'Send emails via Email Workers',
+
   // Other
   'firstpartytags:write': 'Configure first-party tags'
 } as const

--- a/src/auth/scopes.ts
+++ b/src/auth/scopes.ts
@@ -121,7 +121,9 @@ export const ALL_SCOPES = {
   'mcp_portals:write': 'Create and modify MCP Portals',
 
   // Email
+  'email_routing:read': 'View email routing rules',
   'email_routing:write': 'Configure email routing rules',
+  'email_sending:read': 'View email sending configurations',
   'email_sending:write': 'Send emails via Email Workers',
 
   // Other
@@ -158,7 +160,9 @@ export const SCOPE_TEMPLATES = {
       'dns_settings:read',
       'dns_analytics:read',
       'zone:read',
-      'logpush:read'
+      'logpush:read',
+      'email_routing:read',
+      'email_sending:read'
     ] as ScopeName[]
   },
   'workers-full': {

--- a/src/tests/auth/scopes.test.ts
+++ b/src/tests/auth/scopes.test.ts
@@ -92,6 +92,8 @@ const REGISTERED_SCOPES = [
   'notebook-examples:read',
   'mcp_portals:read',
   'mcp_portals:write',
+  'email_routing:write',
+  'email_sending:write',
   'firstpartytags:write'
 ] as const
 

--- a/src/tests/auth/scopes.test.ts
+++ b/src/tests/auth/scopes.test.ts
@@ -92,7 +92,9 @@ const REGISTERED_SCOPES = [
   'notebook-examples:read',
   'mcp_portals:read',
   'mcp_portals:write',
+  'email_routing:read',
   'email_routing:write',
+  'email_sending:read',
   'email_sending:write',
   'firstpartytags:write'
 ] as const


### PR DESCRIPTION
## Summary
- Adds `email_routing:write` and `email_sending:write` OAuth scopes to `ALL_SCOPES` in `src/auth/scopes.ts`
- Registers both scopes in the test file to pass validation

## Test plan
- [x] `vitest run src/tests/auth/scopes.test.ts` — all 10 tests pass