### PR TITLE
fix: remove email_routing:read and email_sending:read scopes

### DIFF
--- a/src/auth/scopes.ts
+++ b/src/auth/scopes.ts
@@ -121,9 +121,7 @@ export const ALL_SCOPES = {
   'mcp_portals:write': 'Create and modify MCP Portals',
 
   // Email
-  'email_routing:read': 'View email routing rules',
   'email_routing:write': 'Configure email routing rules',
-  'email_sending:read': 'View email sending configurations',
   'email_sending:write': 'Send emails via Email Workers',
 
   // Other
@@ -160,9 +158,7 @@ export const SCOPE_TEMPLATES = {
       'dns_settings:read',
       'dns_analytics:read',
       'zone:read',
-      'logpush:read',
-      'email_routing:read',
-      'email_sending:read'
+      'logpush:read'
     ] as ScopeName[]
   },
   'workers-full': {

--- a/src/tests/auth/scopes.test.ts
+++ b/src/tests/auth/scopes.test.ts
@@ -92,9 +92,7 @@ const REGISTERED_SCOPES = [
   'notebook-examples:read',
   'mcp_portals:read',
   'mcp_portals:write',
-  'email_routing:read',
   'email_routing:write',
-  'email_sending:read',
   'email_sending:write',
   'firstpartytags:write'
 ] as const


### PR DESCRIPTION
## Summary
- Remove `email_routing:read` and `email_sending:read` from ALL_SCOPES and the read-only template
- The OAuth2 client only has write scopes registered, so these read scopes would fail at authorization

## Test plan
- [x] `scopes.test.ts` passes