### PR TITLE
fix: exponential backoff on 429 responses from Cloudflare API

### DIFF
--- a/src/auth/oauth-handler.ts
+++ b/src/auth/oauth-handler.ts
@@ -62,10 +62,11 @@ async function fetchCloudflareProbes(accessToken: string): Promise<[Response, Re
   const headers = { Authorization: `Bearer ${accessToken}` }
 
   try {
-    return (await Promise.all([
+    const [userResp, accountsResp] = await Promise.all([
       fetchWithRetry(`${env.CLOUDFLARE_API_BASE}/user`, { headers }),
       fetchWithRetry(`${env.CLOUDFLARE_API_BASE}/accounts`, { headers })
-    ])) as [Response, Response]
+    ])
+    return [userResp, accountsResp]
   } catch (error) {
     console.error('Cloudflare API request failed', error)
     throw new OAuthError('server_error', 'Cloudflare API is temporarily unavailable', 502)

--- a/src/auth/oauth-handler.ts
+++ b/src/auth/oauth-handler.ts
@@ -21,6 +21,7 @@ import {
   validateOAuthState,
   OAuthError
 } from './workers-oauth-utils'
+import { fetchWithRetry } from '../utils/fetch-retry'
 
 import type {
   AuthRequest,
@@ -61,10 +62,10 @@ async function fetchCloudflareProbes(accessToken: string): Promise<[Response, Re
   const headers = { Authorization: `Bearer ${accessToken}` }
 
   try {
-    return await Promise.all([
-      fetch(`${env.CLOUDFLARE_API_BASE}/user`, { headers }),
-      fetch(`${env.CLOUDFLARE_API_BASE}/accounts`, { headers })
-    ])
+    return (await Promise.all([
+      fetchWithRetry(`${env.CLOUDFLARE_API_BASE}/user`, { headers }),
+      fetchWithRetry(`${env.CLOUDFLARE_API_BASE}/accounts`, { headers })
+    ])) as [Response, Response]
   } catch (error) {
     console.error('Cloudflare API request failed', error)
     throw new OAuthError('server_error', 'Cloudflare API is temporarily unavailable', 502)

--- a/src/auth/oauth-handler.ts
+++ b/src/auth/oauth-handler.ts
@@ -62,11 +62,10 @@ async function fetchCloudflareProbes(accessToken: string): Promise<[Response, Re
   const headers = { Authorization: `Bearer ${accessToken}` }
 
   try {
-    const [userResp, accountsResp] = await Promise.all([
+    return await Promise.all([
       fetchWithRetry(`${env.CLOUDFLARE_API_BASE}/user`, { headers }),
       fetchWithRetry(`${env.CLOUDFLARE_API_BASE}/accounts`, { headers })
     ])
-    return [userResp, accountsResp]
   } catch (error) {
     console.error('Cloudflare API request failed', error)
     throw new OAuthError('server_error', 'Cloudflare API is temporarily unavailable', 502)

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { createServer } from './server'
 import { createAuthHandlers, handleTokenExchangeCallback } from './auth/oauth-handler'
 import { isDirectApiToken, handleApiTokenRequest } from './auth/api-token-mode'
 import { processSpec, extractProducts } from './spec-processor'
+import { fetchWithRetry } from './utils/fetch-retry'
 import type { AuthProps } from './auth/types'
 
 /**
@@ -29,7 +30,7 @@ export class GlobalOutbound extends WorkerEntrypoint<Env, GlobalOutboundProps> {
         ['Authorization', `Bearer ${this.ctx.props.apiToken}`]
       ])
     })
-    return fetch(authedRequest)
+    return fetchWithRetry(authedRequest)
   }
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,6 +2,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { z } from 'zod'
 import { createCodeExecutor, createSearchExecutor } from './executor'
 import { truncateResponse } from './truncate'
+import { fetchWithRetry } from './utils/fetch-retry'
 import type { AuthProps } from './auth/types'
 
 const CLOUDFLARE_TYPES = `
@@ -340,7 +341,7 @@ async function registerNonCodemodeTools(
             requestBody = params['body'] as string
           }
 
-          const response = await fetch(url.toString(), {
+          const response = await fetchWithRetry(url.toString(), {
             method: method.toUpperCase(),
             headers,
             body: requestBody

--- a/src/tests/auth/oauth-handler.test.ts
+++ b/src/tests/auth/oauth-handler.test.ts
@@ -3,6 +3,16 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { getUserAndAccounts } from '../../auth/oauth-handler'
 import { OAuthError } from '../../auth/workers-oauth-utils'
 
+// Use minimal retry config so tests don't wait for real backoff delays
+vi.mock('../../utils/fetch-retry', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../../utils/fetch-retry')>()
+  return {
+    ...original,
+    fetchWithRetry: (input: RequestInfo, init?: RequestInit) =>
+      original.fetchWithRetry(input, init, { maxRetries: 0 })
+  }
+})
+
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
     status,
@@ -220,8 +230,7 @@ describe('getUserAndAccounts', () => {
   it('maps fetch rejection to server_error', async () => {
     const fetchMock = vi
       .fn<typeof fetch>()
-      .mockRejectedValueOnce(new TypeError('network failed'))
-      .mockResolvedValueOnce(jsonResponse({ success: true, result: [] }))
+      .mockRejectedValue(new TypeError('network failed'))
 
     vi.stubGlobal('fetch', fetchMock)
 

--- a/src/tests/auth/oauth-handler.test.ts
+++ b/src/tests/auth/oauth-handler.test.ts
@@ -228,9 +228,7 @@ describe('getUserAndAccounts', () => {
   })
 
   it('maps fetch rejection to server_error', async () => {
-    const fetchMock = vi
-      .fn<typeof fetch>()
-      .mockRejectedValue(new TypeError('network failed'))
+    const fetchMock = vi.fn<typeof fetch>().mockRejectedValue(new TypeError('network failed'))
 
     vi.stubGlobal('fetch', fetchMock)
 

--- a/src/tests/fetch-retry.test.ts
+++ b/src/tests/fetch-retry.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { fetchWithRetry, computeRetryDelay, type RetryOptions } from '../utils/fetch-retry'
+
+describe('computeRetryDelay', () => {
+  const defaults: Required<RetryOptions> = {
+    maxRetries: 3,
+    baseDelayMs: 1000,
+    backoffFactor: 2,
+    maxDelayMs: 30_000,
+    jitter: false,
+  }
+
+  it('computes exponential delays without jitter', () => {
+    expect(computeRetryDelay(0, defaults)).toBe(1000) // 1000 * 2^0
+    expect(computeRetryDelay(1, defaults)).toBe(2000) // 1000 * 2^1
+    expect(computeRetryDelay(2, defaults)).toBe(4000) // 1000 * 2^2
+    expect(computeRetryDelay(3, defaults)).toBe(8000) // 1000 * 2^3
+  })
+
+  it('caps delay at maxDelayMs', () => {
+    const opts = { ...defaults, maxDelayMs: 3000 }
+    expect(computeRetryDelay(5, opts)).toBe(3000) // 1000 * 2^5 = 32000, capped at 3000
+  })
+
+  it('respects Retry-After header (seconds)', () => {
+    expect(computeRetryDelay(0, defaults, '5')).toBe(5000)
+    expect(computeRetryDelay(0, defaults, '2')).toBe(2000)
+  })
+
+  it('caps Retry-After at maxDelayMs', () => {
+    expect(computeRetryDelay(0, defaults, '60')).toBe(30_000)
+  })
+
+  it('ignores invalid Retry-After values', () => {
+    expect(computeRetryDelay(0, defaults, 'invalid')).toBe(1000)
+    expect(computeRetryDelay(0, defaults, '0')).toBe(1000)
+    expect(computeRetryDelay(0, defaults, '-1')).toBe(1000)
+  })
+
+  it('applies jitter between 50% and 100%', () => {
+    const opts = { ...defaults, jitter: true }
+    const results = new Set<number>()
+    for (let i = 0; i < 50; i++) {
+      const delay = computeRetryDelay(0, opts)
+      expect(delay).toBeGreaterThanOrEqual(500)
+      expect(delay).toBeLessThanOrEqual(1000)
+      results.add(Math.round(delay))
+    }
+    // With 50 samples, we should get some variation
+    expect(results.size).toBeGreaterThan(1)
+  })
+})
+
+describe('fetchWithRetry', () => {
+  let originalFetch: typeof globalThis.fetch
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    vi.restoreAllMocks()
+  })
+
+  it('returns immediately on 200', async () => {
+    const mockResponse = new Response('ok', { status: 200 })
+    globalThis.fetch = vi.fn().mockResolvedValue(mockResponse)
+
+    const result = await fetchWithRetry('https://api.example.com/test')
+
+    expect(result.status).toBe(200)
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns immediately on non-429 errors (e.g. 401)', async () => {
+    const mockResponse = new Response('unauthorized', { status: 401 })
+    globalThis.fetch = vi.fn().mockResolvedValue(mockResponse)
+
+    const result = await fetchWithRetry('https://api.example.com/test')
+
+    expect(result.status).toBe(401)
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries on 429 and succeeds', async () => {
+    const mock = vi.fn()
+      .mockResolvedValueOnce(new Response('rate limited', { status: 429 }))
+      .mockResolvedValueOnce(new Response('ok', { status: 200 }))
+    globalThis.fetch = mock
+
+    const result = await fetchWithRetry('https://api.example.com/test', undefined, {
+      maxRetries: 3,
+      baseDelayMs: 10, // fast for tests
+      jitter: false,
+    })
+
+    expect(result.status).toBe(200)
+    expect(mock).toHaveBeenCalledTimes(2)
+  })
+
+  it('returns last 429 response after exhausting retries', async () => {
+    const mock = vi.fn().mockResolvedValue(new Response('rate limited', { status: 429 }))
+    globalThis.fetch = mock
+
+    const result = await fetchWithRetry('https://api.example.com/test', undefined, {
+      maxRetries: 2,
+      baseDelayMs: 10,
+      jitter: false,
+    })
+
+    expect(result.status).toBe(429)
+    // 1 initial + 2 retries = 3 total
+    expect(mock).toHaveBeenCalledTimes(3)
+  })
+
+  it('retries on network errors and succeeds', async () => {
+    const mock = vi.fn()
+      .mockRejectedValueOnce(new Error('network failure'))
+      .mockResolvedValueOnce(new Response('ok', { status: 200 }))
+    globalThis.fetch = mock
+
+    const result = await fetchWithRetry('https://api.example.com/test', undefined, {
+      maxRetries: 3,
+      baseDelayMs: 10,
+      jitter: false,
+    })
+
+    expect(result.status).toBe(200)
+    expect(mock).toHaveBeenCalledTimes(2)
+  })
+
+  it('throws after exhausting retries on network errors', async () => {
+    const mock = vi.fn().mockRejectedValue(new Error('network failure'))
+    globalThis.fetch = mock
+
+    await expect(
+      fetchWithRetry('https://api.example.com/test', undefined, {
+        maxRetries: 1,
+        baseDelayMs: 10,
+        jitter: false,
+      })
+    ).rejects.toThrow('network failure')
+
+    // 1 initial + 1 retry = 2 total
+    expect(mock).toHaveBeenCalledTimes(2)
+  })
+
+  it('passes through request init options', async () => {
+    const mockResponse = new Response('ok', { status: 200 })
+    globalThis.fetch = vi.fn().mockResolvedValue(mockResponse)
+
+    await fetchWithRetry('https://api.example.com/test', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token' },
+      body: '{"key":"value"}',
+    })
+
+    expect(globalThis.fetch).toHaveBeenCalledWith('https://api.example.com/test', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token' },
+      body: '{"key":"value"}',
+    })
+  })
+
+  it('respects Retry-After header from 429 response', async () => {
+    const headers429 = new Headers({ 'Retry-After': '1' })
+    const mock = vi.fn()
+      .mockResolvedValueOnce(new Response('rate limited', { status: 429, headers: headers429 }))
+      .mockResolvedValueOnce(new Response('ok', { status: 200 }))
+    globalThis.fetch = mock
+
+    const start = Date.now()
+    const result = await fetchWithRetry('https://api.example.com/test', undefined, {
+      maxRetries: 3,
+      baseDelayMs: 10, // would be 10ms without Retry-After
+      jitter: false,
+    })
+
+    const elapsed = Date.now() - start
+    expect(result.status).toBe(200)
+    // Retry-After: 1 means 1000ms minimum
+    expect(elapsed).toBeGreaterThanOrEqual(900) // allow small timing variance
+  })
+
+  it('handles mixed network errors and 429s', async () => {
+    const mock = vi.fn()
+      .mockRejectedValueOnce(new Error('network failure'))
+      .mockResolvedValueOnce(new Response('rate limited', { status: 429 }))
+      .mockResolvedValueOnce(new Response('ok', { status: 200 }))
+    globalThis.fetch = mock
+
+    const result = await fetchWithRetry('https://api.example.com/test', undefined, {
+      maxRetries: 3,
+      baseDelayMs: 10,
+      jitter: false,
+    })
+
+    expect(result.status).toBe(200)
+    expect(mock).toHaveBeenCalledTimes(3)
+  })
+
+  it('returns 429 if last response was 429 even after network errors', async () => {
+    const mock = vi.fn()
+      .mockRejectedValueOnce(new Error('network failure'))
+      .mockResolvedValueOnce(new Response('rate limited', { status: 429 }))
+    globalThis.fetch = mock
+
+    const result = await fetchWithRetry('https://api.example.com/test', undefined, {
+      maxRetries: 1,
+      baseDelayMs: 10,
+      jitter: false,
+    })
+
+    expect(result.status).toBe(429)
+    expect(mock).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/tests/fetch-retry.test.ts
+++ b/src/tests/fetch-retry.test.ts
@@ -6,7 +6,7 @@ describe('computeRetryDelay', () => {
     maxRetries: 3,
     baseDelayMs: 1000,
     backoffFactor: 2,
-    maxDelayMs: 30_000,
+    maxDelayMs: 5_000,
     jitter: false,
   }
 
@@ -14,12 +14,11 @@ describe('computeRetryDelay', () => {
     expect(computeRetryDelay(0, defaults)).toBe(1000) // 1000 * 2^0
     expect(computeRetryDelay(1, defaults)).toBe(2000) // 1000 * 2^1
     expect(computeRetryDelay(2, defaults)).toBe(4000) // 1000 * 2^2
-    expect(computeRetryDelay(3, defaults)).toBe(8000) // 1000 * 2^3
+    expect(computeRetryDelay(3, defaults)).toBe(5000) // 1000 * 2^3 = 8000, capped at 5000
   })
 
   it('caps delay at maxDelayMs', () => {
-    const opts = { ...defaults, maxDelayMs: 3000 }
-    expect(computeRetryDelay(5, opts)).toBe(3000) // 1000 * 2^5 = 32000, capped at 3000
+    expect(computeRetryDelay(5, defaults)).toBe(5000) // 1000 * 2^5 = 32000, capped at 5000
   })
 
   it('respects Retry-After header (seconds)', () => {
@@ -28,7 +27,7 @@ describe('computeRetryDelay', () => {
   })
 
   it('caps Retry-After at maxDelayMs', () => {
-    expect(computeRetryDelay(0, defaults, '60')).toBe(30_000)
+    expect(computeRetryDelay(0, defaults, '60')).toBe(5_000)
   })
 
   it('ignores invalid Retry-After values', () => {

--- a/src/tests/fetch-retry.test.ts
+++ b/src/tests/fetch-retry.test.ts
@@ -6,7 +6,7 @@ describe('computeRetryDelay', () => {
     maxRetries: 3,
     baseDelayMs: 1000,
     backoffFactor: 2,
-    maxDelayMs: 5_000,
+    maxDelayMs: 30_000,
     jitter: false
   }
 
@@ -14,11 +14,11 @@ describe('computeRetryDelay', () => {
     expect(computeRetryDelay(0, defaults)).toBe(1000) // 1000 * 2^0
     expect(computeRetryDelay(1, defaults)).toBe(2000) // 1000 * 2^1
     expect(computeRetryDelay(2, defaults)).toBe(4000) // 1000 * 2^2
-    expect(computeRetryDelay(3, defaults)).toBe(5000) // 1000 * 2^3 = 8000, capped at 5000
+    expect(computeRetryDelay(3, defaults)).toBe(8000) // 1000 * 2^3
   })
 
   it('caps delay at maxDelayMs', () => {
-    expect(computeRetryDelay(5, defaults)).toBe(5000) // 1000 * 2^5 = 32000, capped at 5000
+    expect(computeRetryDelay(5, defaults)).toBe(30_000) // 1000 * 2^5 = 32000, capped at 30000
   })
 
   it('respects Retry-After header (seconds)', () => {
@@ -27,7 +27,7 @@ describe('computeRetryDelay', () => {
   })
 
   it('caps Retry-After at maxDelayMs', () => {
-    expect(computeRetryDelay(0, defaults, '60')).toBe(5_000)
+    expect(computeRetryDelay(0, defaults, '60')).toBe(30_000) // 60s capped at 30s
   })
 
   it('ignores invalid Retry-After values', () => {

--- a/src/tests/fetch-retry.test.ts
+++ b/src/tests/fetch-retry.test.ts
@@ -7,7 +7,7 @@ describe('computeRetryDelay', () => {
     baseDelayMs: 1000,
     backoffFactor: 2,
     maxDelayMs: 5_000,
-    jitter: false,
+    jitter: false
   }
 
   it('computes exponential delays without jitter', () => {
@@ -83,7 +83,8 @@ describe('fetchWithRetry', () => {
   })
 
   it('retries on 429 and succeeds', async () => {
-    const mock = vi.fn()
+    const mock = vi
+      .fn()
       .mockResolvedValueOnce(new Response('rate limited', { status: 429 }))
       .mockResolvedValueOnce(new Response('ok', { status: 200 }))
     globalThis.fetch = mock
@@ -91,7 +92,7 @@ describe('fetchWithRetry', () => {
     const result = await fetchWithRetry('https://api.example.com/test', undefined, {
       maxRetries: 3,
       baseDelayMs: 10, // fast for tests
-      jitter: false,
+      jitter: false
     })
 
     expect(result.status).toBe(200)
@@ -105,7 +106,7 @@ describe('fetchWithRetry', () => {
     const result = await fetchWithRetry('https://api.example.com/test', undefined, {
       maxRetries: 2,
       baseDelayMs: 10,
-      jitter: false,
+      jitter: false
     })
 
     expect(result.status).toBe(429)
@@ -114,7 +115,8 @@ describe('fetchWithRetry', () => {
   })
 
   it('retries on network errors and succeeds', async () => {
-    const mock = vi.fn()
+    const mock = vi
+      .fn()
       .mockRejectedValueOnce(new Error('network failure'))
       .mockResolvedValueOnce(new Response('ok', { status: 200 }))
     globalThis.fetch = mock
@@ -122,7 +124,7 @@ describe('fetchWithRetry', () => {
     const result = await fetchWithRetry('https://api.example.com/test', undefined, {
       maxRetries: 3,
       baseDelayMs: 10,
-      jitter: false,
+      jitter: false
     })
 
     expect(result.status).toBe(200)
@@ -137,7 +139,7 @@ describe('fetchWithRetry', () => {
       fetchWithRetry('https://api.example.com/test', undefined, {
         maxRetries: 1,
         baseDelayMs: 10,
-        jitter: false,
+        jitter: false
       })
     ).rejects.toThrow('network failure')
 
@@ -152,19 +154,20 @@ describe('fetchWithRetry', () => {
     await fetchWithRetry('https://api.example.com/test', {
       method: 'POST',
       headers: { Authorization: 'Bearer token' },
-      body: '{"key":"value"}',
+      body: '{"key":"value"}'
     })
 
     expect(globalThis.fetch).toHaveBeenCalledWith('https://api.example.com/test', {
       method: 'POST',
       headers: { Authorization: 'Bearer token' },
-      body: '{"key":"value"}',
+      body: '{"key":"value"}'
     })
   })
 
   it('respects Retry-After header from 429 response', async () => {
     const headers429 = new Headers({ 'Retry-After': '1' })
-    const mock = vi.fn()
+    const mock = vi
+      .fn()
       .mockResolvedValueOnce(new Response('rate limited', { status: 429, headers: headers429 }))
       .mockResolvedValueOnce(new Response('ok', { status: 200 }))
     globalThis.fetch = mock
@@ -173,7 +176,7 @@ describe('fetchWithRetry', () => {
     const result = await fetchWithRetry('https://api.example.com/test', undefined, {
       maxRetries: 3,
       baseDelayMs: 10, // would be 10ms without Retry-After
-      jitter: false,
+      jitter: false
     })
 
     const elapsed = Date.now() - start
@@ -183,7 +186,8 @@ describe('fetchWithRetry', () => {
   })
 
   it('handles mixed network errors and 429s', async () => {
-    const mock = vi.fn()
+    const mock = vi
+      .fn()
       .mockRejectedValueOnce(new Error('network failure'))
       .mockResolvedValueOnce(new Response('rate limited', { status: 429 }))
       .mockResolvedValueOnce(new Response('ok', { status: 200 }))
@@ -192,7 +196,7 @@ describe('fetchWithRetry', () => {
     const result = await fetchWithRetry('https://api.example.com/test', undefined, {
       maxRetries: 3,
       baseDelayMs: 10,
-      jitter: false,
+      jitter: false
     })
 
     expect(result.status).toBe(200)
@@ -200,7 +204,8 @@ describe('fetchWithRetry', () => {
   })
 
   it('returns 429 if last response was 429 even after network errors', async () => {
-    const mock = vi.fn()
+    const mock = vi
+      .fn()
       .mockRejectedValueOnce(new Error('network failure'))
       .mockResolvedValueOnce(new Response('rate limited', { status: 429 }))
     globalThis.fetch = mock
@@ -208,7 +213,7 @@ describe('fetchWithRetry', () => {
     const result = await fetchWithRetry('https://api.example.com/test', undefined, {
       maxRetries: 1,
       baseDelayMs: 10,
-      jitter: false,
+      jitter: false
     })
 
     expect(result.status).toBe(429)

--- a/src/tests/non-codemode.test.ts
+++ b/src/tests/non-codemode.test.ts
@@ -3,6 +3,16 @@ import { pathToToolName, buildInputSchema, createServer } from '../server'
 import type { OperationInfo } from '../server'
 import type { AuthProps } from '../auth/types'
 
+// Use minimal retry config so tests don't wait for real backoff delays
+vi.mock('../utils/fetch-retry', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../utils/fetch-retry')>()
+  return {
+    ...original,
+    fetchWithRetry: (input: RequestInfo, init?: RequestInit) =>
+      original.fetchWithRetry(input, init, { maxRetries: 0 })
+  }
+})
+
 describe('pathToToolName', () => {
   it('keeps accounts in name, strips param', () => {
     expect(pathToToolName('get', '/accounts/{account_id}/workers/scripts')).toBe(

--- a/src/utils/fetch-retry.ts
+++ b/src/utils/fetch-retry.ts
@@ -5,7 +5,7 @@ export interface RetryOptions {
   baseDelayMs?: number
   /** Multiplier applied to delay after each retry (default: 2) */
   backoffFactor?: number
-  /** Maximum delay cap in ms (default: 5000) */
+  /** Maximum delay cap in ms (default: 30000) */
   maxDelayMs?: number
   /** Add random jitter to prevent thundering herd (default: true) */
   jitter?: boolean
@@ -15,7 +15,7 @@ const DEFAULT_OPTIONS: Required<RetryOptions> = {
   maxRetries: 3,
   baseDelayMs: 1000,
   backoffFactor: 2,
-  maxDelayMs: 5_000, // Keep low — Workers have a 30s wall clock limit
+  maxDelayMs: 30_000, // Sleep is I/O wait (not billed CPU). Workers allow 15min wall clock.
   jitter: true
 }
 

--- a/src/utils/fetch-retry.ts
+++ b/src/utils/fetch-retry.ts
@@ -15,8 +15,8 @@ const DEFAULT_OPTIONS: Required<RetryOptions> = {
   maxRetries: 3,
   baseDelayMs: 1000,
   backoffFactor: 2,
-  maxDelayMs: 5_000,  // Keep low — Workers have a 30s wall clock limit
-  jitter: true,
+  maxDelayMs: 5_000, // Keep low — Workers have a 30s wall clock limit
+  jitter: true
 }
 
 /**
@@ -29,7 +29,7 @@ const DEFAULT_OPTIONS: Required<RetryOptions> = {
 export function computeRetryDelay(
   attempt: number,
   opts: Required<RetryOptions>,
-  retryAfterHeader?: string | null,
+  retryAfterHeader?: string | null
 ): number {
   // Respect Retry-After header if present (value in seconds)
   if (retryAfterHeader) {
@@ -58,7 +58,7 @@ export function computeRetryDelay(
 export async function fetchWithRetry(
   input: RequestInfo,
   init?: RequestInit,
-  options?: RetryOptions,
+  options?: RetryOptions
 ): Promise<Response> {
   const opts = { ...DEFAULT_OPTIONS, ...options }
 
@@ -80,7 +80,7 @@ export async function fetchWithRetry(
         const delay = computeRetryDelay(attempt, opts, response.headers.get('Retry-After'))
         console.warn(
           `fetchWithRetry: 429 on attempt ${attempt + 1}/${opts.maxRetries + 1}, ` +
-            `retrying in ${Math.round(delay)}ms`,
+            `retrying in ${Math.round(delay)}ms`
         )
         await sleep(delay)
       }
@@ -92,7 +92,7 @@ export async function fetchWithRetry(
         const delay = computeRetryDelay(attempt, opts, null)
         console.warn(
           `fetchWithRetry: network error on attempt ${attempt + 1}/${opts.maxRetries + 1}, ` +
-            `retrying in ${Math.round(delay)}ms: ${error instanceof Error ? error.message : error}`,
+            `retrying in ${Math.round(delay)}ms: ${error instanceof Error ? error.message : error}`
         )
         await sleep(delay)
       }

--- a/src/utils/fetch-retry.ts
+++ b/src/utils/fetch-retry.ts
@@ -1,0 +1,113 @@
+export interface RetryOptions {
+  /** Maximum number of retry attempts (default: 3) */
+  maxRetries?: number
+  /** Base delay in ms before first retry (default: 1000) */
+  baseDelayMs?: number
+  /** Multiplier applied to delay after each retry (default: 2) */
+  backoffFactor?: number
+  /** Maximum delay cap in ms (default: 30000) */
+  maxDelayMs?: number
+  /** Add random jitter to prevent thundering herd (default: true) */
+  jitter?: boolean
+}
+
+const DEFAULT_OPTIONS: Required<RetryOptions> = {
+  maxRetries: 3,
+  baseDelayMs: 1000,
+  backoffFactor: 2,
+  maxDelayMs: 30_000,
+  jitter: true,
+}
+
+/**
+ * Compute the delay before the next retry attempt.
+ *
+ * Uses exponential backoff with optional jitter:
+ *   delay = min(baseDelay * factor^attempt, maxDelay)
+ *   if jitter: delay *= random(0.5, 1.0)
+ */
+export function computeRetryDelay(
+  attempt: number,
+  opts: Required<RetryOptions>,
+  retryAfterHeader?: string | null,
+): number {
+  // Respect Retry-After header if present (value in seconds)
+  if (retryAfterHeader) {
+    const seconds = Number(retryAfterHeader)
+    if (!Number.isNaN(seconds) && seconds > 0) {
+      // Still cap it so a misbehaving server can't stall us forever
+      return Math.min(seconds * 1000, opts.maxDelayMs)
+    }
+  }
+
+  const exponentialDelay = opts.baseDelayMs * opts.backoffFactor ** attempt
+  const capped = Math.min(exponentialDelay, opts.maxDelayMs)
+
+  if (!opts.jitter) return capped
+
+  // Jitter between 50% and 100% of the computed delay
+  return capped * (0.5 + Math.random() * 0.5)
+}
+
+/**
+ * Fetch with automatic retries on HTTP 429 (Too Many Requests).
+ *
+ * All other status codes are returned immediately without retrying.
+ * Network errors (fetch throws) are also retried.
+ */
+export async function fetchWithRetry(
+  input: RequestInfo,
+  init?: RequestInit,
+  options?: RetryOptions,
+): Promise<Response> {
+  const opts = { ...DEFAULT_OPTIONS, ...options }
+
+  let lastResponse: Response | undefined
+  let lastError: unknown
+
+  for (let attempt = 0; attempt <= opts.maxRetries; attempt++) {
+    try {
+      const response = await fetch(input, init)
+
+      if (response.status !== 429) {
+        return response
+      }
+
+      // 429 — will retry if we have attempts left
+      lastResponse = response
+
+      if (attempt < opts.maxRetries) {
+        const delay = computeRetryDelay(attempt, opts, response.headers.get('Retry-After'))
+        console.warn(
+          `fetchWithRetry: 429 on attempt ${attempt + 1}/${opts.maxRetries + 1}, ` +
+            `retrying in ${Math.round(delay)}ms`,
+        )
+        await sleep(delay)
+      }
+    } catch (error) {
+      // Network error — retry if we have attempts left
+      lastError = error
+
+      if (attempt < opts.maxRetries) {
+        const delay = computeRetryDelay(attempt, opts, null)
+        console.warn(
+          `fetchWithRetry: network error on attempt ${attempt + 1}/${opts.maxRetries + 1}, ` +
+            `retrying in ${Math.round(delay)}ms: ${error instanceof Error ? error.message : error}`,
+        )
+        await sleep(delay)
+      }
+    }
+  }
+
+  // Exhausted all retries
+  if (lastResponse) {
+    return lastResponse
+  }
+
+  // All attempts failed with network errors
+  throw lastError
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}

--- a/src/utils/fetch-retry.ts
+++ b/src/utils/fetch-retry.ts
@@ -1,13 +1,8 @@
 export interface RetryOptions {
-  /** Maximum number of retry attempts (default: 3) */
   maxRetries?: number
-  /** Base delay in ms before first retry (default: 1000) */
   baseDelayMs?: number
-  /** Multiplier applied to delay after each retry (default: 2) */
   backoffFactor?: number
-  /** Maximum delay cap in ms (default: 30000) */
   maxDelayMs?: number
-  /** Add random jitter to prevent thundering herd (default: true) */
   jitter?: boolean
 }
 
@@ -15,27 +10,17 @@ const DEFAULT_OPTIONS: Required<RetryOptions> = {
   maxRetries: 3,
   baseDelayMs: 1000,
   backoffFactor: 2,
-  maxDelayMs: 30_000, // Sleep is I/O wait (not billed CPU). Workers allow 15min wall clock.
+  maxDelayMs: 30_000,
   jitter: true
 }
-
-/**
- * Compute the delay before the next retry attempt.
- *
- * Uses exponential backoff with optional jitter:
- *   delay = min(baseDelay * factor^attempt, maxDelay)
- *   if jitter: delay *= random(0.5, 1.0)
- */
 export function computeRetryDelay(
   attempt: number,
   opts: Required<RetryOptions>,
   retryAfterHeader?: string | null
 ): number {
-  // Respect Retry-After header if present (value in seconds)
   if (retryAfterHeader) {
     const seconds = Number(retryAfterHeader)
     if (!Number.isNaN(seconds) && seconds > 0) {
-      // Still cap it so a misbehaving server can't stall us forever
       return Math.min(seconds * 1000, opts.maxDelayMs)
     }
   }
@@ -45,16 +30,9 @@ export function computeRetryDelay(
 
   if (!opts.jitter) return capped
 
-  // Jitter between 50% and 100% of the computed delay
   return capped * (0.5 + Math.random() * 0.5)
 }
 
-/**
- * Fetch with automatic retries on HTTP 429 (Too Many Requests).
- *
- * All other status codes are returned immediately without retrying.
- * Network errors (fetch throws) are also retried.
- */
 export async function fetchWithRetry(
   input: RequestInfo,
   init?: RequestInit,
@@ -73,7 +51,6 @@ export async function fetchWithRetry(
         return response
       }
 
-      // 429 — will retry if we have attempts left
       lastResponse = response
 
       if (attempt < opts.maxRetries) {
@@ -85,7 +62,6 @@ export async function fetchWithRetry(
         await sleep(delay)
       }
     } catch (error) {
-      // Network error — retry if we have attempts left
       lastError = error
 
       if (attempt < opts.maxRetries) {
@@ -99,12 +75,10 @@ export async function fetchWithRetry(
     }
   }
 
-  // Exhausted all retries
   if (lastResponse) {
     return lastResponse
   }
 
-  // All attempts failed with network errors
   throw lastError
 }
 

--- a/src/utils/fetch-retry.ts
+++ b/src/utils/fetch-retry.ts
@@ -5,7 +5,7 @@ export interface RetryOptions {
   baseDelayMs?: number
   /** Multiplier applied to delay after each retry (default: 2) */
   backoffFactor?: number
-  /** Maximum delay cap in ms (default: 30000) */
+  /** Maximum delay cap in ms (default: 5000) */
   maxDelayMs?: number
   /** Add random jitter to prevent thundering herd (default: true) */
   jitter?: boolean
@@ -15,7 +15,7 @@ const DEFAULT_OPTIONS: Required<RetryOptions> = {
   maxRetries: 3,
   baseDelayMs: 1000,
   backoffFactor: 2,
-  maxDelayMs: 30_000,
+  maxDelayMs: 5_000,  // Keep low — Workers have a 30s wall clock limit
   jitter: true,
 }
 


### PR DESCRIPTION
## Problem

The MCP worker hits Cloudflare API rate limits (429) on `/user` and `/accounts` probe calls during auth, causing immediate failures with no retry:

```
Cloudflare API error: user=429, accounts=429
```

## Solution

Add a `fetchWithRetry` utility that wraps `fetch` with exponential backoff on HTTP 429 and network errors. Respects `Retry-After` header from the Cloudflare API.

### Defaults

| Option | Value |
|--------|-------|
| `maxRetries` | 3 |
| `baseDelayMs` | 1000 |
| `backoffFactor` | 2 |
| `maxDelayMs` | 30000 |
| `jitter` | true |

Retry delays: ~1s → ~2s → ~4s (with jitter). Sleep time is I/O wait, not billed CPU time. HTTP-triggered Workers have [unlimited wall clock time](https://developers.cloudflare.com/workers/platform/limits/#wall-time-limits-by-invocation-type).

### Applied to all Cloudflare API call sites

| Call site | File |
|-----------|------|
| Auth probes (`/user` + `/accounts`) | `src/auth/oauth-handler.ts` |
| Non-codemode tool handler | `src/server.ts` |
| Code executor outbound (`GlobalOutbound`) | `src/index.ts` |

### Tests

16 new tests for the retry utility. All 163 tests pass.

Deployed and verified on staging (`staging.mcp.cloudflare.com`).