### PR TITLE
Add Claude Code connection guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@
 
 MCP URL: `https://mcp.cloudflare.com/mcp`
 
+Connection guides:
+
+- [Claude Code](docs/connection-guides/claude-code.md)
+
 ### Option 1: OAuth (Recommended)
 
 Just connect to the MCP server URL - you'll be redirected to Cloudflare to authorize and select permissions.

--- a/docs/connection-guides/claude-code.md
+++ b/docs/connection-guides/claude-code.md
@@ -1,10 +1,33 @@
 # Claude Code
 
-Add the Cloudflare MCP server to Claude Code with a `.mcp.json` file.
+Connect [Claude Code](https://code.claude.com/docs/en/overview) to the Cloudflare MCP server with one command:
 
-## OAuth
+```bash
+claude mcp add --transport http cloudflare-api https://mcp.cloudflare.com/mcp
+```
 
-For the hosted Cloudflare MCP server, add this configuration:
+Then run `/mcp` inside Claude Code to sign in. Cloudflare will prompt you to
+authorize access and select permissions with OAuth.
+
+## API Token
+
+For CI/CD and automation, skip OAuth and pass a
+[Cloudflare API token](https://dash.cloudflare.com/profile/api-tokens) as a
+bearer token:
+
+```bash
+claude mcp add --transport http cloudflare-api https://mcp.cloudflare.com/mcp \
+  --header "Authorization: Bearer YOUR_CLOUDFLARE_API_TOKEN"
+```
+
+Both user tokens and account tokens are supported. For account tokens, include
+the **Account Resources : Read** permission so the server can auto-detect your
+account ID.
+
+## Share with Your Team
+
+To check the server into your repo, add a `.mcp.json` file at the project root
+(or run the command above with `--scope project`):
 
 ```json
 {
@@ -17,50 +40,13 @@ For the hosted Cloudflare MCP server, add this configuration:
 }
 ```
 
-Restart Claude Code after saving the file. Claude Code will connect over HTTP
-and Cloudflare will prompt you to authorize access with OAuth.
-
-## API Token
-
-For automation or CI/CD workflows, create a
-[Cloudflare API token](https://dash.cloudflare.com/profile/api-tokens) with the
-permissions your agent needs, then pass it as a bearer token:
-
-```json
-{
-  "mcpServers": {
-    "cloudflare-api": {
-      "type": "http",
-      "url": "https://mcp.cloudflare.com/mcp",
-      "headers": {
-        "Authorization": "Bearer ${CLOUDFLARE_API_TOKEN}"
-      }
-    }
-  }
-}
-```
-
-Both user tokens and account tokens are supported. For account tokens, include
-the **Account Resources : Read** permission so the server can auto-detect your
-account ID. Claude Code expands environment variables in `.mcp.json`, so keep
-the token in your shell environment instead of committing the value to the file.
+Claude Code expands environment variables in `.mcp.json`, so an API token
+header can reference `${CLOUDFLARE_API_TOKEN}` instead of committing the value
+to the file.
 
 ## Disable Code Mode
 
-If you need each Cloudflare API endpoint exposed as an individual tool, add
-`?codemode=false` to the URL:
-
-```json
-{
-  "mcpServers": {
-    "cloudflare-api": {
-      "type": "http",
-      "url": "https://mcp.cloudflare.com/mcp?codemode=false"
-    }
-  }
-}
-```
-
-Only disable code mode when needed. It significantly increases the token cost
-because the server registers thousands of endpoint-specific tools instead of
-the compact code mode tools.
+To expose each Cloudflare API endpoint as an individual tool instead of the
+compact code mode tools, add `?codemode=false` to the URL. This registers
+~2,500 endpoint-specific tools and uses far more context, so only disable code
+mode when you need it.

--- a/docs/connection-guides/claude-code.md
+++ b/docs/connection-guides/claude-code.md
@@ -1,0 +1,66 @@
+# Claude Code
+
+Add the Cloudflare MCP server to Claude Code with a `.mcp.json` file.
+
+## OAuth
+
+For the hosted Cloudflare MCP server, add this configuration:
+
+```json
+{
+  "mcpServers": {
+    "cloudflare-api": {
+      "type": "http",
+      "url": "https://mcp.cloudflare.com/mcp"
+    }
+  }
+}
+```
+
+Restart Claude Code after saving the file. Claude Code will connect over HTTP
+and Cloudflare will prompt you to authorize access with OAuth.
+
+## API Token
+
+For automation or CI/CD workflows, create a
+[Cloudflare API token](https://dash.cloudflare.com/profile/api-tokens) with the
+permissions your agent needs, then pass it as a bearer token:
+
+```json
+{
+  "mcpServers": {
+    "cloudflare-api": {
+      "type": "http",
+      "url": "https://mcp.cloudflare.com/mcp",
+      "headers": {
+        "Authorization": "Bearer ${CLOUDFLARE_API_TOKEN}"
+      }
+    }
+  }
+}
+```
+
+Both user tokens and account tokens are supported. For account tokens, include
+the **Account Resources : Read** permission so the server can auto-detect your
+account ID. Claude Code expands environment variables in `.mcp.json`, so keep
+the token in your shell environment instead of committing the value to the file.
+
+## Disable Code Mode
+
+If you need each Cloudflare API endpoint exposed as an individual tool, add
+`?codemode=false` to the URL:
+
+```json
+{
+  "mcpServers": {
+    "cloudflare-api": {
+      "type": "http",
+      "url": "https://mcp.cloudflare.com/mcp?codemode=false"
+    }
+  }
+}
+```
+
+Only disable code mode when needed. It significantly increases the token cost
+because the server registers thousands of endpoint-specific tools instead of
+the compact code mode tools.


### PR DESCRIPTION
## Summary
- add `docs/connection-guides/claude-code.md` with Claude Code `.mcp.json` examples
- document the required `type: "http"` field for the hosted Cloudflare MCP server
- include OAuth, API token, and `codemode=false` configurations
- link the guide from the README

Closes #39

## Testing
- `git diff --cached --check`
- `git diff --check`