### PR TITLE
Improve fetchWithRetry failure logging

### DIFF
--- a/src/auth/api-token-mode.ts
+++ b/src/auth/api-token-mode.ts
@@ -51,7 +51,7 @@ export async function handleApiTokenRequest(
   }
 
   try {
-    const { user, accounts } = await getUserAndAccounts(token)
+    const { user, accounts } = await getUserAndAccounts(token, 'api_token_identity_probe')
 
     // Account-scoped token
     if (!user) {

--- a/src/auth/oauth-handler.ts
+++ b/src/auth/oauth-handler.ts
@@ -211,13 +211,16 @@ function throwCombinedCloudflareApiError(userResp: Response, accountsResp: Respo
   throw new OAuthError('invalid_token', 'Failed to verify token', userResp.status)
 }
 
-async function fetchCloudflareProbes(accessToken: string): Promise<[Response, Response]> {
+async function fetchCloudflareProbes(
+  accessToken: string,
+  caller = 'oauth_callback_identity_probe'
+): Promise<[Response, Response]> {
   const headers = { Authorization: `Bearer ${accessToken}` }
 
   try {
     return await Promise.all([
-      fetchWithRetry(`${env.CLOUDFLARE_API_BASE}/user`, { headers }),
-      fetchWithRetry(`${env.CLOUDFLARE_API_BASE}/accounts`, { headers })
+      fetchWithRetry(`${env.CLOUDFLARE_API_BASE}/user`, { headers }, { caller }),
+      fetchWithRetry(`${env.CLOUDFLARE_API_BASE}/accounts`, { headers }, { caller })
     ])
   } catch (error) {
     console.error('Cloudflare API request failed', error)
@@ -228,11 +231,14 @@ async function fetchCloudflareProbes(accessToken: string): Promise<[Response, Re
 /**
  * Fetch user and accounts from Cloudflare API
  */
-export async function getUserAndAccounts(accessToken: string): Promise<{
+export async function getUserAndAccounts(
+  accessToken: string,
+  caller = 'oauth_callback_identity_probe'
+): Promise<{
   user: UserSchema | null
   accounts: AccountSchema[]
 }> {
-  const [userResp, accountsResp] = await fetchCloudflareProbes(accessToken)
+  const [userResp, accountsResp] = await fetchCloudflareProbes(accessToken, caller)
 
   // Check for upstream errors before parsing
   if (!userResp.ok && !accountsResp.ok) {

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -14,7 +14,9 @@ export function createCodeExecutor(env: Env, ctx: ExecutionContext) {
 
     const worker = env.LOADER.get(workerId, () => ({
       compatibilityDate: '2026-01-12',
-      globalOutbound: ctx.exports.GlobalOutbound({ props: { apiToken } }),
+      globalOutbound: ctx.exports.GlobalOutbound({
+        props: { apiToken, fetchWithRetryCaller: 'codemode_execute_tool_call' }
+      }),
       mainModule: 'worker.js',
       modules: {
         'worker.js': `

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ import type { AuthProps } from './auth/types'
  * to only make requests to the configured Cloudflare API base URL.
  * The API token is injected via props so it never enters the user code isolate.
  */
-type GlobalOutboundProps = { apiToken: string }
+type GlobalOutboundProps = { apiToken: string; fetchWithRetryCaller: string }
 
 export class GlobalOutbound extends WorkerEntrypoint<Env, GlobalOutboundProps> {
   async fetch(request: Request): Promise<Response> {
@@ -30,7 +30,9 @@ export class GlobalOutbound extends WorkerEntrypoint<Env, GlobalOutboundProps> {
         ['Authorization', `Bearer ${this.ctx.props.apiToken}`]
       ])
     })
-    return fetchWithRetry(authedRequest)
+    return fetchWithRetry(authedRequest, undefined, {
+      caller: this.ctx.props.fetchWithRetryCaller
+    })
   }
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -341,11 +341,15 @@ async function registerNonCodemodeTools(
             requestBody = params['body'] as string
           }
 
-          const response = await fetchWithRetry(url.toString(), {
-            method: method.toUpperCase(),
-            headers,
-            body: requestBody
-          })
+          const response = await fetchWithRetry(
+            url.toString(),
+            {
+              method: method.toUpperCase(),
+              headers,
+              body: requestBody
+            },
+            { caller: 'non_codemode_tool_call' }
+          )
 
           const contentType = response.headers.get('content-type') || ''
           let result: string

--- a/src/tests/fetch-retry.test.ts
+++ b/src/tests/fetch-retry.test.ts
@@ -52,9 +52,13 @@ describe('computeRetryDelay', () => {
 
 describe('fetchWithRetry', () => {
   let originalFetch: typeof globalThis.fetch
+  let warnSpy: ReturnType<typeof vi.spyOn>
+  let errorSpy: ReturnType<typeof vi.spyOn>
 
   beforeEach(() => {
     originalFetch = globalThis.fetch
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
   })
 
   afterEach(() => {
@@ -82,6 +86,26 @@ describe('fetchWithRetry', () => {
     expect(globalThis.fetch).toHaveBeenCalledTimes(1)
   })
 
+  it('logs caller and url when retrying 429s', async () => {
+    const mock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('rate limited', { status: 429 }))
+      .mockResolvedValueOnce(new Response('ok', { status: 200 }))
+    globalThis.fetch = mock
+
+    const result = await fetchWithRetry('https://api.example.com/accounts', undefined, {
+      maxRetries: 1,
+      baseDelayMs: 1,
+      jitter: false,
+      caller: 'oauth_callback_identity_probe'
+    })
+
+    expect(result.status).toBe(200)
+    expect(warnSpy).toHaveBeenCalledWith(
+      'fetchWithRetry: 429 caller=oauth_callback_identity_probe url=https://api.example.com/accounts on attempt 1/2, retrying in 1ms'
+    )
+  })
+
   it('retries on 429 and succeeds', async () => {
     const mock = vi
       .fn()
@@ -97,6 +121,20 @@ describe('fetchWithRetry', () => {
 
     expect(result.status).toBe(200)
     expect(mock).toHaveBeenCalledTimes(2)
+  })
+
+  it('logs an error after exhausting 429 retries', async () => {
+    const mock = vi.fn().mockResolvedValue(new Response('rate limited', { status: 429 }))
+    globalThis.fetch = mock
+
+    const result = await fetchWithRetry('https://api.example.com/accounts', undefined, {
+      maxRetries: 0
+    })
+
+    expect(result.status).toBe(429)
+    expect(errorSpy).toHaveBeenCalledWith(
+      'fetchWithRetry: failed url=https://api.example.com/accounts after 1 attempts with status 429'
+    )
   })
 
   it('returns last 429 response after exhausting retries', async () => {
@@ -129,6 +167,23 @@ describe('fetchWithRetry', () => {
 
     expect(result.status).toBe(200)
     expect(mock).toHaveBeenCalledTimes(2)
+  })
+
+  it('logs an error after exhausting network retries', async () => {
+    const error = new Error('network failure')
+    const mock = vi.fn().mockRejectedValue(error)
+    globalThis.fetch = mock
+
+    await expect(
+      fetchWithRetry('https://api.example.com/accounts', undefined, {
+        maxRetries: 0
+      })
+    ).rejects.toThrow('network failure')
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      'fetchWithRetry: failed url=https://api.example.com/accounts after 1 attempts',
+      error
+    )
   })
 
   it('throws after exhausting retries on network errors', async () => {

--- a/src/utils/fetch-retry.ts
+++ b/src/utils/fetch-retry.ts
@@ -4,9 +4,10 @@ export interface RetryOptions {
   backoffFactor?: number
   maxDelayMs?: number
   jitter?: boolean
+  caller?: string
 }
 
-const DEFAULT_OPTIONS: Required<RetryOptions> = {
+const DEFAULT_OPTIONS: Required<Omit<RetryOptions, 'caller'>> = {
   maxRetries: 3,
   baseDelayMs: 1000,
   backoffFactor: 2,
@@ -15,7 +16,7 @@ const DEFAULT_OPTIONS: Required<RetryOptions> = {
 }
 export function computeRetryDelay(
   attempt: number,
-  opts: Required<RetryOptions>,
+  opts: Required<Omit<RetryOptions, 'caller'>>,
   retryAfterHeader?: string | null
 ): number {
   if (retryAfterHeader) {
@@ -39,6 +40,8 @@ export async function fetchWithRetry(
   options?: RetryOptions
 ): Promise<Response> {
   const opts = { ...DEFAULT_OPTIONS, ...options }
+  const url = typeof input === 'string' ? input : input.url
+  const caller = options?.caller ? ` caller=${options.caller}` : ''
 
   let lastResponse: Response | undefined
   let lastError: unknown
@@ -56,7 +59,7 @@ export async function fetchWithRetry(
       if (attempt < opts.maxRetries) {
         const delay = computeRetryDelay(attempt, opts, response.headers.get('Retry-After'))
         console.warn(
-          `fetchWithRetry: 429 on attempt ${attempt + 1}/${opts.maxRetries + 1}, ` +
+          `fetchWithRetry: 429${caller} url=${url} on attempt ${attempt + 1}/${opts.maxRetries + 1}, ` +
             `retrying in ${Math.round(delay)}ms`
         )
         await sleep(delay)
@@ -67,7 +70,7 @@ export async function fetchWithRetry(
       if (attempt < opts.maxRetries) {
         const delay = computeRetryDelay(attempt, opts, null)
         console.warn(
-          `fetchWithRetry: network error on attempt ${attempt + 1}/${opts.maxRetries + 1}, ` +
+          `fetchWithRetry: network error${caller} url=${url} on attempt ${attempt + 1}/${opts.maxRetries + 1}, ` +
             `retrying in ${Math.round(delay)}ms: ${error instanceof Error ? error.message : error}`
         )
         await sleep(delay)
@@ -76,9 +79,16 @@ export async function fetchWithRetry(
   }
 
   if (lastResponse) {
+    console.error(
+      `fetchWithRetry: failed${caller} url=${url} after ${opts.maxRetries + 1} attempts with status ${lastResponse.status}`
+    )
     return lastResponse
   }
 
+  console.error(
+    `fetchWithRetry: failed${caller} url=${url} after ${opts.maxRetries + 1} attempts`,
+    lastError
+  )
   throw lastError
 }
 


### PR DESCRIPTION
## Summary

This improves `fetchWithRetry` diagnostics so 429s and exhausted retry failures can be tied back to the Cloudflare API request and call path that triggered them.

Changes:
- Add `url=...` to `fetchWithRetry` 429 retry warnings and network retry warnings.
- Add `console.error` logs when retries are exhausted for either a final 429 response or repeated network failures.
- Add an optional `caller` label to `fetchWithRetry` logs.
- Wire caller labels at the known Cloudflare API call paths:
  - `oauth_callback_identity_probe`
  - `api_token_identity_probe`
  - `codemode_execute_tool_call`
  - `non_codemode_tool_call`
- Add tests covering the URL/caller warning output and final failure error logs.

Example log:

```txt
fetchWithRetry: 429 caller=oauth_callback_identity_probe url=https://api.cloudflare.com/client/v4/accounts on attempt 1/4, retrying in 1000ms
```

## Why

We need to distinguish whether observed Cloudflare API 429s are coming from identity probes during OAuth/API-token setup or from actual tool execution paths. This logging should make that visible without adding token-hash caching or changing retry behavior.

## Tests

- `npm run check`

Note: `npm run check` passes with an existing oxlint warning in `src/tests/cloudflare-test.d.ts` about a triple-slash reference.