### PR TITLE
Cache API token identity probe fetches

### DIFF
--- a/src/auth/api-token-mode.ts
+++ b/src/auth/api-token-mode.ts
@@ -3,6 +3,11 @@ import { OAuthError } from './workers-oauth-utils'
 
 import type { AuthProps } from './types'
 
+async function hashApiToken(token: string): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(token))
+  return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, '0')).join('')
+}
+
 /**
  * Check if the request contains a direct Cloudflare API token
  * (as opposed to an OAuth token issued by workers-oauth-provider)
@@ -51,7 +56,11 @@ export async function handleApiTokenRequest(
   }
 
   try {
-    const { user, accounts } = await getUserAndAccounts(token, 'api_token_identity_probe')
+    const { user, accounts } = await getUserAndAccounts(
+      token,
+      'api_token_identity_probe',
+      await hashApiToken(token)
+    )
 
     // Account-scoped token
     if (!user) {

--- a/src/auth/oauth-handler.ts
+++ b/src/auth/oauth-handler.ts
@@ -213,14 +213,25 @@ function throwCombinedCloudflareApiError(userResp: Response, accountsResp: Respo
 
 async function fetchCloudflareProbes(
   accessToken: string,
-  caller = 'oauth_callback_identity_probe'
+  caller = 'oauth_callback_identity_probe',
+  apiTokenCacheKeyHash?: string
 ): Promise<[Response, Response]> {
   const headers = { Authorization: `Bearer ${accessToken}` }
+  const userUrl = `${env.CLOUDFLARE_API_BASE}/user`
+  const accountsUrl = `${env.CLOUDFLARE_API_BASE}/accounts`
+  const cacheCf = (path: 'user' | 'accounts') =>
+    apiTokenCacheKeyHash
+      ? {
+          cacheEverything: true,
+          cacheKey: `${env.CLOUDFLARE_API_BASE}/mcp/api-token-identity/${apiTokenCacheKeyHash}/${path}`,
+          cacheTtl: 2_592_000
+        }
+      : undefined
 
   try {
     return await Promise.all([
-      fetchWithRetry(`${env.CLOUDFLARE_API_BASE}/user`, { headers }, { caller }),
-      fetchWithRetry(`${env.CLOUDFLARE_API_BASE}/accounts`, { headers }, { caller })
+      fetchWithRetry(userUrl, { headers, cf: cacheCf('user') }, { caller }),
+      fetchWithRetry(accountsUrl, { headers, cf: cacheCf('accounts') }, { caller })
     ])
   } catch (error) {
     console.error('Cloudflare API request failed', error)
@@ -233,12 +244,17 @@ async function fetchCloudflareProbes(
  */
 export async function getUserAndAccounts(
   accessToken: string,
-  caller = 'oauth_callback_identity_probe'
+  caller = 'oauth_callback_identity_probe',
+  apiTokenCacheKeyHash?: string
 ): Promise<{
   user: UserSchema | null
   accounts: AccountSchema[]
 }> {
-  const [userResp, accountsResp] = await fetchCloudflareProbes(accessToken, caller)
+  const [userResp, accountsResp] = await fetchCloudflareProbes(
+    accessToken,
+    caller,
+    apiTokenCacheKeyHash
+  )
 
   // Check for upstream errors before parsing
   if (!userResp.ok && !accountsResp.ok) {

--- a/src/tests/auth/api-token-mode.test.ts
+++ b/src/tests/auth/api-token-mode.test.ts
@@ -1,5 +1,17 @@
-import { describe, it, expect } from 'vitest'
-import { isDirectApiToken, extractBearerToken, buildAuthProps } from '../../auth/api-token-mode'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { getUserAndAccounts } from '../../auth/oauth-handler'
+import {
+  isDirectApiToken,
+  extractBearerToken,
+  buildAuthProps,
+  handleApiTokenRequest
+} from '../../auth/api-token-mode'
+
+vi.mock('../../auth/oauth-handler', () => ({
+  getUserAndAccounts: vi.fn()
+}))
+
+const getUserAndAccountsMock = vi.mocked(getUserAndAccounts)
 
 /**
  * Helper to create a mock Request with given Authorization header
@@ -11,6 +23,10 @@ function mockRequest(authHeader?: string): Request {
   }
   return new Request('https://example.com', { headers })
 }
+
+beforeEach(() => {
+  getUserAndAccountsMock.mockReset()
+})
 
 describe('isDirectApiToken', () => {
   it('should return false for requests without Authorization header', () => {
@@ -130,5 +146,26 @@ describe('buildAuthProps', () => {
     const props = buildAuthProps(mockToken, undefined, mockAccounts)
 
     expect(props.type).toBe('account_token')
+  })
+})
+
+describe('handleApiTokenRequest identity probe caching', () => {
+  const token = 'api-token-123'
+  const user = { id: 'user-1', email: 'test@example.com' }
+  const accounts = [{ id: 'acc-1', name: 'Account One' }]
+
+  it('passes a stable token hash for Cloudflare fetch cache keys', async () => {
+    getUserAndAccountsMock.mockResolvedValue({ user, accounts })
+    const createMcpResponse = vi.fn().mockResolvedValue(new Response('ok'))
+    const request = mockRequest(`Bearer ${token}`)
+
+    await handleApiTokenRequest(request, createMcpResponse)
+
+    expect(getUserAndAccountsMock).toHaveBeenCalledTimes(1)
+    expect(getUserAndAccountsMock).toHaveBeenCalledWith(
+      token,
+      'api_token_identity_probe',
+      '9bdb81d121b42d1c7819c816fa3cfbb6ee109726f9ed2475edb169374881d7b3'
+    )
   })
 })

--- a/src/tests/auth/oauth-handler.test.ts
+++ b/src/tests/auth/oauth-handler.test.ts
@@ -128,6 +128,51 @@ describe('getUserAndAccounts', () => {
     })
   })
 
+  it('sets Cloudflare fetch cache options for API token identity probes', async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response('Forbidden', { status: 403 }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          success: true,
+          result: [{ id: 'acc-1', name: 'Primary Account' }]
+        })
+      )
+
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(
+      getUserAndAccounts('test-token', 'api_token_identity_probe', 'token-hash')
+    ).resolves.toEqual({
+      user: null,
+      accounts: [{ id: 'acc-1', name: 'Primary Account' }]
+    })
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      'https://api.cloudflare.com/client/v4/user',
+      expect.objectContaining({
+        cf: {
+          cacheEverything: true,
+          cacheKey: 'https://api.cloudflare.com/client/v4/mcp/api-token-identity/token-hash/user',
+          cacheTtl: 2_592_000
+        }
+      })
+    )
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      'https://api.cloudflare.com/client/v4/accounts',
+      expect.objectContaining({
+        cf: {
+          cacheEverything: true,
+          cacheKey:
+            'https://api.cloudflare.com/client/v4/mcp/api-token-identity/token-hash/accounts',
+          cacheTtl: 2_592_000
+        }
+      })
+    )
+  })
+
   it('accepts user tokens when /accounts fails but /user succeeds', async () => {
     const fetchMock = vi
       .fn<typeof fetch>()


### PR DESCRIPTION
## Summary

The `fetchWithRetry` caller labels showed repeated 429s from `api_token_identity_probe` on both `/user` and `/accounts`. This patch caches those upstream fetches using the simple Cloudflare Workers `cf` cache options from the Request docs.

Changes:
- Hash direct API tokens with SHA-256 and pass the token hash into the API-token identity probe path.
- Add `cf` cache options to the `/user` and `/accounts` identity probe fetches for API-token mode only.
- Use separate cache keys for `/user` and `/accounts` identity probes.
- Cache with `cacheEverything: true` and `cacheTtl: 2_592_000` (30 days).
- Add tests for the stable token hash and generated `cf` cache options.

## Why

Direct API-token requests verify identity by calling both:

```txt
/user
/accounts
```

Logs show these are hitting rate limits:

```txt
fetchWithRetry: 429 caller=api_token_identity_probe url=https://api.cloudflare.com/client/v4/user on attempt 1/4, retrying in 1000ms
fetchWithRetry: 429 caller=api_token_identity_probe url=https://api.cloudflare.com/client/v4/accounts on attempt 1/4, retrying in 1000ms
```

Worker isolate memory is unlikely to help much across production isolates, so this uses the Workers fetch cache path. The cache key includes only a SHA-256 token hash, never the raw token. Successful identity metadata for an API token is effectively immutable, so this caches identity probe responses with a 30-day TTL.

## Tests

- `npm run check`
- `npm run format:check && npm run typecheck && npm test -- src/tests/auth/oauth-handler.test.ts`

Note: `npm run check` passes with an existing oxlint warning in `src/tests/cloudflare-test.d.ts` about a triple-slash reference.