### PR TITLE
Remove API token cache happy-path logs

### DIFF
--- a/src/auth/api-token-mode.ts
+++ b/src/auth/api-token-mode.ts
@@ -21,26 +21,21 @@ async function hashApiToken(token: string): Promise<string> {
 async function getCachedApiTokenIdentity(token: string): Promise<ApiTokenIdentity> {
   const tokenHash = await hashApiToken(token)
   const cacheKey = `api-token-identity:${tokenHash}`
-  const tokenHashPrefix = tokenHash.slice(0, 8)
-
   try {
     const cached = await env.OAUTH_KV.get<ApiTokenIdentity>(cacheKey, 'json')
     if (cached) {
-      console.log(`api_token_identity_probe kv-cache status=HIT token_hash=${tokenHashPrefix}`)
       return cached
     }
   } catch (error) {
     console.warn('api_token_identity_probe kv-cache read failed', error)
   }
 
-  console.log(`api_token_identity_probe kv-cache status=MISS token_hash=${tokenHashPrefix}`)
   const identity = await getUserAndAccounts(token, 'api_token_identity_probe')
 
   try {
     await env.OAUTH_KV.put(cacheKey, JSON.stringify(identity), {
       expirationTtl: API_TOKEN_IDENTITY_CACHE_TTL_SECONDS
     })
-    console.log(`api_token_identity_probe kv-cache status=STORE token_hash=${tokenHashPrefix}`)
   } catch (error) {
     console.warn('api_token_identity_probe kv-cache write failed', error)
   }

--- a/src/tests/auth/api-token-mode.test.ts
+++ b/src/tests/auth/api-token-mode.test.ts
@@ -162,7 +162,6 @@ describe('handleApiTokenRequest identity probe caching', () => {
   const accounts = [{ id: 'acc-1', name: 'Account One' }]
 
   it('stores API token identity lookups in KV by token hash', async () => {
-    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
     const getSpy = vi.spyOn(env.OAUTH_KV, 'get').mockResolvedValue(null)
     const putSpy = vi.spyOn(env.OAUTH_KV, 'put').mockResolvedValue(undefined)
     getUserAndAccountsMock.mockResolvedValue({ user, accounts })
@@ -177,16 +176,9 @@ describe('handleApiTokenRequest identity probe caching', () => {
     expect(putSpy).toHaveBeenCalledWith(cacheKey, JSON.stringify({ user, accounts }), {
       expirationTtl: 2_592_000
     })
-    expect(logSpy).toHaveBeenCalledWith(
-      'api_token_identity_probe kv-cache status=MISS token_hash=9bdb81d1'
-    )
-    expect(logSpy).toHaveBeenCalledWith(
-      'api_token_identity_probe kv-cache status=STORE token_hash=9bdb81d1'
-    )
   })
 
   it('uses cached API token identity from KV', async () => {
-    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
     vi.spyOn(env.OAUTH_KV, 'get').mockResolvedValue({ user, accounts })
     const putSpy = vi.spyOn(env.OAUTH_KV, 'put').mockResolvedValue(undefined)
     const createMcpResponse = vi.fn().mockResolvedValue(new Response('ok'))
@@ -200,9 +192,6 @@ describe('handleApiTokenRequest identity probe caching', () => {
       token,
       undefined,
       buildAuthProps(token, user, accounts)
-    )
-    expect(logSpy).toHaveBeenCalledWith(
-      'api_token_identity_probe kv-cache status=HIT token_hash=9bdb81d1'
     )
   })
 })


### PR DESCRIPTION
## Summary

PR #125 has already merged, so this follow-up removes the noisy happy-path KV cache logs from API-token identity probing.

Changes:
- Remove `console.log` for KV cache HIT/MISS/STORE.
- Keep `console.warn` for KV read/write failures.
- Update tests to assert cache behavior without log expectations.

## Tests

- `npm run format`
- `npm run typecheck`
- `npm test -- src/tests/auth/api-token-mode.test.ts`
- `npm run lint`

Note: lint passes with the existing `src/tests/cloudflare-test.d.ts` triple-slash-reference warning.