### PR TITLE
fix: enable coalesceRefreshTokenExchange to stop invalid_grant storms

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "cloudflare-mcp",
       "version": "0.1.0",
       "dependencies": {
-        "@cloudflare/workers-oauth-provider": "^0.6.0",
+        "@cloudflare/workers-oauth-provider": "https://pkg.pr.new/cloudflare/workers-oauth-provider/@cloudflare/workers-oauth-provider@216",
         "@modelcontextprotocol/sdk": "^1.26.0",
         "hono": "^4.12.7",
         "zod": "^4.3.5"
@@ -154,9 +154,9 @@
       }
     },
     "node_modules/@cloudflare/workers-oauth-provider": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-oauth-provider/-/workers-oauth-provider-0.6.0.tgz",
-      "integrity": "sha512-KOkTWEjwVjfYGU78eyapKziuPuzKw9gIg4LpxbGmxWhNl4bAdiJzWXeV3nepFr+vmkEiTMEGk99Llj5j0tH2cw==",
+      "version": "0.7.0",
+      "resolved": "https://pkg.pr.new/cloudflare/workers-oauth-provider/@cloudflare/workers-oauth-provider@216",
+      "integrity": "sha512-SbwCm7evlbxjflBOyHd+tgnpe8UkxtmEReFbej5pkc9IKx9VxgJ9wJikhTOIDVscVfYn8/BRwxn4HQ969E84EQ==",
       "license": "MIT"
     },
     "node_modules/@cspotcode/source-map-support": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "seed:prod": "tsx scripts/seed-r2.ts production"
   },
   "dependencies": {
-    "@cloudflare/workers-oauth-provider": "^0.6.0",
+    "@cloudflare/workers-oauth-provider": "https://pkg.pr.new/cloudflare/workers-oauth-provider/@cloudflare/workers-oauth-provider@216",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "hono": "^4.12.7",
     "zod": "^4.3.5"

--- a/src/index.ts
+++ b/src/index.ts
@@ -123,7 +123,14 @@ export default {
       accessTokenTTL: 3600,
       refreshTokenTTL: 2592000, // 30 days
       // TODO: Remove after 2026-05-01 — all pre-0.4.0 grants will have expired by then
-      resourceMatchOriginOnly: true
+      resourceMatchOriginOnly: true,
+      // Our tokenExchangeCallback redeems a single-use, rotating upstream
+      // Cloudflare refresh token, so the refresh_token grant is non-idempotent.
+      // Coalesce concurrent same-token refreshes and replay previous-token
+      // retries without re-hitting upstream, to stop the invalid_grant storms
+      // when a token is shared across sessions / refreshes race.
+      // See cloudflare/workers-oauth-provider#216.
+      coalesceRefreshTokenExchange: true
     }).fetch(request, env, ctx)
   },
 


### PR DESCRIPTION
## Problem

We see a steady stream of:

```
Token refresh failed: 400 {"error":"invalid_grant","error_description":"The provided authorization grant ... refresh token is invalid, expired, revoked ..."}
```

Our `tokenExchangeCallback` redeems a **single-use, rotating** upstream Cloudflare refresh token, so the downstream `refresh_token` grant is non-idempotent. Two conditions trigger the errors:

1. **Shared token / concurrent refresh** — a refresh token used by two sessions (e.g. two chat windows) gets refreshed simultaneously. Both decrypt the same upstream credentials and both call the upstream token endpoint, racing to redeem the same single-use upstream token. One wins; the rest get `invalid_grant`.
2. **Lost response / retry** — a client retries with its previous refresh token; the callback re-runs against the already-rotated upstream token, redeeming it again and cascading further rotations.

## Fix

Enable the new opt-in **`coalesceRefreshTokenExchange`** option in `@cloudflare/workers-oauth-provider`:

- **Single-flight** — concurrent `refresh_token` requests for the same token within an isolate are coalesced; the callback (and upstream redemption) runs once and all callers share the response.
- **Idempotent replay** — a refresh presented with the grant's *previous* token is treated as a retry of the rotation that already happened: the callback is skipped and a fresh access token is minted from current props without re-hitting upstream.

## Provider dependency

Pinned to the **pkg.pr.new preview build** of cloudflare/workers-oauth-provider#216 (the PR that adds this option) for a production soak:

```
"@cloudflare/workers-oauth-provider": "https://pkg.pr.new/cloudflare/workers-oauth-provider/@cloudflare/workers-oauth-provider@216"
```

This will be switched back to a normal semver range once #216 ships.

## Rollback

Revert this PR (or just the dependency pin) to return to `^0.6.0` with default behaviour. The option is opt-in and changes nothing else.

## Checks

- `npm run typecheck` ✅
- `npm test` ✅ 183/183
- `npm run format:check` ✅
