### PR TITLE
Revoke grant on upstream invalid_grant during token refresh

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/matt/Documents/Github/cloudflare-mcp/node_modules

--- a/src/auth/oauth-handler.ts
+++ b/src/auth/oauth-handler.ts
@@ -68,6 +68,73 @@ function isTerminalRefreshError(error: unknown): error is OAuthError {
   )
 }
 
+/**
+ * Context needed to kill the downstream grant + emit telemetry when an upstream
+ * refresh fails. Optional so the guard stays usable in isolation (tests).
+ */
+export interface RefreshGuardContext {
+  /** Downstream OAuth user id (from the token-exchange callback options). */
+  userId?: string
+  /** Downstream OAuth client id (from the token-exchange callback options). */
+  clientId?: string
+  /**
+   * Lazily builds OAuth helpers (via `getOAuthApi`). Only invoked on a terminal
+   * `invalid_grant` so we don't construct the provider on every refresh.
+   */
+  getHelpers?: () => OAuthHelpers
+}
+
+type RefreshFailureKind = 'upstream_terminal' | 'cached_replay' | 'in_flight_collision'
+
+/**
+ * Structured, greppable telemetry for refresh failures. Logged as a single JSON
+ * line prefixed with `[refresh-telemetry]` so it can be counted in Workers Logs.
+ *
+ * `kind` distinguishes the cases you want to measure:
+ *  - `upstream_terminal`: upstream /oauth2/token actually returned a terminal
+ *    error this request (the *first-time* failure). `grantsRevoked` tells you
+ *    whether we killed the grant.
+ *  - `cached_replay`: a retry that short-circuited on the cached failure within
+ *    REFRESH_FAILURE_TTL_SECONDS (a *repeat*, never hit upstream).
+ *  - `in_flight_collision`: another isolate was mid-refresh.
+ */
+function logRefreshTelemetry(event: {
+  kind: RefreshFailureKind
+  code: string
+  refreshTokenHash: string
+  userId?: string
+  clientId?: string
+  grantsRevoked?: number
+}): void {
+  console.error(`[refresh-telemetry] ${JSON.stringify({ ...event, at: Date.now() })}`)
+}
+
+/**
+ * Kill every grant for this user+client. `completeAuthorization` revokes prior
+ * grants for the same user+client by default, so in practice there is at most
+ * one, but we loop defensively (and paginate). `revokeGrant` deletes all access
+ * tokens for the grant and the grant record itself, which invalidates the
+ * downstream refresh token too.
+ */
+async function revokeGrantsForClient(
+  helpers: OAuthHelpers,
+  userId: string,
+  clientId: string
+): Promise<number> {
+  let revoked = 0
+  let cursor: string | undefined
+  do {
+    const page = await helpers.listUserGrants(userId, cursor ? { cursor } : undefined)
+    for (const grant of page.items) {
+      if (grant.clientId !== clientId) continue
+      await helpers.revokeGrant(grant.id, userId)
+      revoked++
+    }
+    cursor = page.cursor
+  } while (cursor)
+  return revoked
+}
+
 async function getCachedRefreshFailure(
   kv: KVNamespace,
   failureKey: string
@@ -132,7 +199,8 @@ async function clearRefreshInFlight(kv: KVNamespace, inFlightKey: string): Promi
 export async function guardRefreshTokenExchange(
   kv: KVNamespace,
   refreshToken: string,
-  refresh: () => Promise<TokenExchangeCallbackResult | undefined>
+  refresh: () => Promise<TokenExchangeCallbackResult | undefined>,
+  context: RefreshGuardContext = {}
 ): Promise<TokenExchangeCallbackResult | undefined> {
   const refreshTokenHash = await sha256Hex(refreshToken)
   const keys = refreshGuardKeys(refreshTokenHash)
@@ -143,14 +211,31 @@ export async function guardRefreshTokenExchange(
     try {
       const cachedFailure = await getCachedRefreshFailure(kv, keys.failure)
       if (cachedFailure) {
+        const code = cachedFailure.code || 'invalid_grant'
+        // A retry of an already-failed token within the cache TTL. The grant was
+        // already killed on the first failure; this never reaches upstream.
+        logRefreshTelemetry({
+          kind: 'cached_replay',
+          code,
+          refreshTokenHash,
+          userId: context.userId,
+          clientId: context.clientId
+        })
         throw new OAuthError(
-          cachedFailure.code || 'invalid_grant',
+          code,
           cachedFailure.description || 'Token refresh recently failed; reauthorization is required',
           400
         )
       }
 
       if (await isRefreshInFlight(kv, keys.inFlight)) {
+        logRefreshTelemetry({
+          kind: 'in_flight_collision',
+          code: 'temporarily_unavailable',
+          refreshTokenHash,
+          userId: context.userId,
+          clientId: context.clientId
+        })
         throw new OAuthError(
           'temporarily_unavailable',
           'Token refresh is already in progress; retry shortly',
@@ -166,6 +251,41 @@ export async function guardRefreshTokenExchange(
       } catch (error) {
         if (isTerminalRefreshError(error)) {
           await cacheRefreshFailure(kv, keys.failure, error)
+
+          // The core fix: when upstream rejects the stored refresh token with
+          // invalid_grant it is permanently dead, so kill the downstream grant
+          // and force re-auth instead of letting the client retry forever.
+          // Other terminal codes (invalid_client/unauthorized_client) are
+          // server-side credential problems that revoking wouldn't fix.
+          let grantsRevoked = 0
+          if (
+            error.code === 'invalid_grant' &&
+            context.userId &&
+            context.clientId &&
+            context.getHelpers
+          ) {
+            try {
+              grantsRevoked = await revokeGrantsForClient(
+                context.getHelpers(),
+                context.userId,
+                context.clientId
+              )
+            } catch (revokeError) {
+              console.error(
+                'Refresh guard: failed to revoke grant after invalid_grant',
+                revokeError
+              )
+            }
+          }
+
+          logRefreshTelemetry({
+            kind: 'upstream_terminal',
+            code: error.code,
+            refreshTokenHash,
+            userId: context.userId,
+            clientId: context.clientId,
+            grantsRevoked
+          })
         }
         throw error
       } finally {
@@ -311,7 +431,14 @@ export async function getUserAndAccounts(
 export async function handleTokenExchangeCallback(
   options: TokenExchangeCallbackOptions,
   clientId: string,
-  clientSecret: string
+  clientSecret: string,
+  /**
+   * Lazily builds OAuth helpers so we can revoke the downstream grant when the
+   * upstream refresh token is rejected with `invalid_grant`. Wired from
+   * `index.ts` (the only place with the full provider options needed by
+   * `getOAuthApi`). Optional so existing callers/tests keep working.
+   */
+  getHelpers?: () => OAuthHelpers
 ): Promise<TokenExchangeCallbackResult | undefined> {
   if (options.grantType !== 'refresh_token') {
     return undefined
@@ -340,23 +467,32 @@ export async function handleTokenExchangeCallback(
 
   const upstreamRefreshToken = props.refreshToken
 
-  return guardRefreshTokenExchange(env.OAUTH_KV, upstreamRefreshToken, async () => {
-    const { access_token, refresh_token, expires_in } = await refreshAuthToken({
-      client_id: clientId,
-      client_secret: clientSecret,
-      refresh_token: upstreamRefreshToken,
-      oauthDomain: env.CLOUDFLARE_OAUTH_DOMAIN
-    })
+  return guardRefreshTokenExchange(
+    env.OAUTH_KV,
+    upstreamRefreshToken,
+    async () => {
+      const { access_token, refresh_token, expires_in } = await refreshAuthToken({
+        client_id: clientId,
+        client_secret: clientSecret,
+        refresh_token: upstreamRefreshToken,
+        oauthDomain: env.CLOUDFLARE_OAUTH_DOMAIN
+      })
 
-    return {
-      newProps: {
-        ...props,
-        accessToken: access_token,
-        refreshToken: refresh_token
-      } satisfies AuthProps,
-      accessTokenTTL: expires_in
+      return {
+        newProps: {
+          ...props,
+          accessToken: access_token,
+          refreshToken: refresh_token
+        } satisfies AuthProps,
+        accessTokenTTL: expires_in
+      }
+    },
+    {
+      userId: options.userId,
+      clientId: options.clientId,
+      getHelpers
     }
-  })
+  )
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import OAuthProvider from '@cloudflare/workers-oauth-provider'
+import OAuthProvider, { getOAuthApi } from '@cloudflare/workers-oauth-provider'
 import { Hono } from 'hono'
 import { WorkerEntrypoint } from 'cloudflare:workers'
 import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js'
@@ -101,7 +101,7 @@ export default {
     }
 
     // OAuth mode - handle via workers-oauth-provider
-    return new OAuthProvider({
+    const oauthOptions: ConstructorParameters<typeof OAuthProvider>[0] = {
       apiHandlers: {
         // @ts-ignore - Hono apps are compatible with ExportedHandler at runtime
         '/mcp': createMcpHandler()
@@ -115,7 +115,11 @@ export default {
         handleTokenExchangeCallback(
           options,
           env.CLOUDFLARE_CLIENT_ID,
-          env.CLOUDFLARE_CLIENT_SECRET
+          env.CLOUDFLARE_CLIENT_SECRET,
+          // Lazily build helpers (only invoked on terminal invalid_grant) so we
+          // can revoke the dead grant. env.OAUTH_PROVIDER is NOT injected during
+          // the token endpoint, so we must construct the API explicitly here.
+          () => getOAuthApi(oauthOptions, env)
         ),
       resourceMetadata: {
         resource_name: 'Cloudflare API MCP Server'
@@ -124,7 +128,8 @@ export default {
       refreshTokenTTL: 2592000, // 30 days
       // TODO: Remove after 2026-05-01 — all pre-0.4.0 grants will have expired by then
       resourceMatchOriginOnly: true
-    }).fetch(request, env, ctx)
+    }
+    return new OAuthProvider(oauthOptions).fetch(request, env, ctx)
   },
 
   async scheduled(

--- a/src/tests/auth/oauth-handler.test.ts
+++ b/src/tests/auth/oauth-handler.test.ts
@@ -72,6 +72,20 @@ function mockKV(initialValues: Record<string, string> = {}): KVNamespace {
   } as unknown as KVNamespace
 }
 
+interface MockGrant {
+  id: string
+  clientId: string
+  userId: string
+}
+
+/** Minimal OAuthHelpers mock backing the revoke-on-invalid_grant path. */
+function mockOAuthHelpers(grants: MockGrant[]) {
+  return {
+    listUserGrants: vi.fn(async () => ({ items: grants as never[], cursor: undefined })),
+    revokeGrant: vi.fn(async () => undefined)
+  }
+}
+
 async function sha256Hex(value: string): Promise<string> {
   const data = new TextEncoder().encode(value)
   const digest = await crypto.subtle.digest('SHA-256', data)
@@ -423,6 +437,131 @@ describe('guardRefreshTokenExchange', () => {
       400
     )
     expect(refreshFn).toHaveBeenCalledTimes(1)
+  })
+
+  it('revokes the grant for this user+client on upstream invalid_grant', async () => {
+    const kv = mockKV()
+    const refreshFn = vi
+      .fn()
+      .mockRejectedValueOnce(new OAuthError('invalid_grant', 'refresh token reused', 400))
+    const helpers = mockOAuthHelpers([
+      { id: 'grant-keep', clientId: 'other-client', userId: 'user-1' },
+      { id: 'grant-kill', clientId: 'mcp-client', userId: 'user-1' }
+    ])
+    const getHelpers = vi.fn(() => helpers)
+
+    await expectOAuthError(
+      guardRefreshTokenExchange(kv, 'dead-token', refreshFn, {
+        userId: 'user-1',
+        clientId: 'mcp-client',
+        getHelpers
+      }),
+      'invalid_grant',
+      400
+    )
+
+    // Only the matching user+client grant is killed; other clients untouched.
+    expect(helpers.listUserGrants).toHaveBeenCalledWith('user-1', undefined)
+    expect(helpers.revokeGrant).toHaveBeenCalledTimes(1)
+    expect(helpers.revokeGrant).toHaveBeenCalledWith('grant-kill', 'user-1')
+  })
+
+  it('does NOT revoke the grant on transient (429/500) refresh errors', async () => {
+    const kv = mockKV()
+    const refreshFn = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new OAuthError('temporarily_unavailable', 'rate limited', 429, { 'Retry-After': '30' })
+      )
+    const helpers = mockOAuthHelpers([{ id: 'grant-1', clientId: 'mcp-client', userId: 'user-1' }])
+    const getHelpers = vi.fn(() => helpers)
+
+    await expectOAuthError(
+      guardRefreshTokenExchange(kv, 'transient-token', refreshFn, {
+        userId: 'user-1',
+        clientId: 'mcp-client',
+        getHelpers
+      }),
+      'temporarily_unavailable',
+      429
+    )
+
+    expect(getHelpers).not.toHaveBeenCalled()
+    expect(helpers.revokeGrant).not.toHaveBeenCalled()
+  })
+
+  it('does NOT revoke the grant on server-side invalid_client', async () => {
+    const kv = mockKV()
+    const refreshFn = vi
+      .fn()
+      .mockRejectedValueOnce(new OAuthError('invalid_client', 'bad client creds', 401))
+    const helpers = mockOAuthHelpers([{ id: 'grant-1', clientId: 'mcp-client', userId: 'user-1' }])
+    const getHelpers = vi.fn(() => helpers)
+
+    await expectOAuthError(
+      guardRefreshTokenExchange(kv, 'bad-client-token', refreshFn, {
+        userId: 'user-1',
+        clientId: 'mcp-client',
+        getHelpers
+      }),
+      'invalid_client',
+      401
+    )
+
+    // invalid_client still caches the failure, but the user's grant survives.
+    expect(helpers.revokeGrant).not.toHaveBeenCalled()
+  })
+
+  it('still throws invalid_grant even if revoking the grant fails', async () => {
+    const kv = mockKV()
+    const refreshFn = vi
+      .fn()
+      .mockRejectedValueOnce(new OAuthError('invalid_grant', 'refresh token reused', 400))
+    const helpers = mockOAuthHelpers([
+      { id: 'grant-kill', clientId: 'mcp-client', userId: 'user-1' }
+    ])
+    vi.mocked(helpers.revokeGrant).mockRejectedValueOnce(new Error('KV unavailable'))
+
+    await expectOAuthError(
+      guardRefreshTokenExchange(kv, 'dead-token-revoke-fails', refreshFn, {
+        userId: 'user-1',
+        clientId: 'mcp-client',
+        getHelpers: () => helpers
+      }),
+      'invalid_grant',
+      400
+    )
+  })
+
+  it('paginates listUserGrants when revoking', async () => {
+    const kv = mockKV()
+    const refreshFn = vi
+      .fn()
+      .mockRejectedValueOnce(new OAuthError('invalid_grant', 'refresh token reused', 400))
+    const helpers = mockOAuthHelpers([])
+    vi.mocked(helpers.listUserGrants)
+      .mockResolvedValueOnce({
+        items: [{ id: 'grant-a', clientId: 'mcp-client', userId: 'user-1' } as never],
+        cursor: 'next'
+      } as never)
+      .mockResolvedValueOnce({
+        items: [{ id: 'grant-b', clientId: 'mcp-client', userId: 'user-1' } as never],
+        cursor: undefined
+      } as never)
+
+    await expectOAuthError(
+      guardRefreshTokenExchange(kv, 'paginated-token', refreshFn, {
+        userId: 'user-1',
+        clientId: 'mcp-client',
+        getHelpers: () => helpers
+      }),
+      'invalid_grant',
+      400
+    )
+
+    expect(helpers.listUserGrants).toHaveBeenCalledTimes(2)
+    expect(helpers.revokeGrant).toHaveBeenCalledWith('grant-a', 'user-1')
+    expect(helpers.revokeGrant).toHaveBeenCalledWith('grant-b', 'user-1')
   })
 })
 


### PR DESCRIPTION
## Problem

When the upstream Cloudflare `/oauth2/token` refresh rejects the stored refresh token with **`invalid_grant`**, that refresh token is permanently dead. Today the downstream grant is left intact, so clients keep retrying the same doomed refresh token — producing a flood of:

```
Token refresh failed: 400 {"error":"invalid_grant", ...}
```

`workers-oauth-provider` discards `newProps` when the `tokenExchangeCallback` throws, so the stale upstream refresh token in the grant is never cleared. Nothing breaks the loop.

## Fix

On a terminal **`invalid_grant`** from the upstream refresh, **revoke the downstream grant** so the client is forced to re-authorize instead of looping.

- **Scoped strictly to `invalid_grant`.** Transient errors (`429`/`500` → `temporarily_unavailable`/`server_error`) and server-side `invalid_client`/`unauthorized_client` do **not** revoke — revoking the user's grant wouldn't fix those and would cause needless re-auth during blips.
- **Helpers built via `getOAuthApi`** inside the callback, because `env.OAUTH_PROVIDER` is **not** injected during the token endpoint. The factory is lazy — only invoked on a terminal `invalid_grant`, so there's no per-refresh cost.
- Revoke failures are swallowed (logged); the client still receives a clean `invalid_grant` 400.

The revoke is unambiguous because the callback only has `userId`+`clientId` (no `grantId`), and `completeAuthorization` already revokes prior grants for the same user+client by default (`revokeExistingGrants` defaults to `true`) — so there's at most one grant per user+client. No change needed there.

## Telemetry

Structured, greppable `[refresh-telemetry] {json}` log lines to measure how many failures are first-time vs retries:

- `kind: "upstream_terminal"` + `grantsRevoked` — upstream actually returned a terminal error this request (the **first-time** failure, and whether we killed the grant).
- `kind: "cached_replay"` — a **retry** short-circuited on the cached failure (never hit upstream).
- `kind: "in_flight_collision"` — another isolate was mid-refresh.

Each includes `code`, `refreshTokenHash`, `userId`, `clientId` for correlation.

## Tests

- Revoke fires on `invalid_grant` and only kills the matching user+client grant.
- Does **not** revoke on transient (429/500) or `invalid_client`.
- Still throws `invalid_grant` when the revoke itself fails.
- `listUserGrants` pagination during revoke.

All 183 tests pass; typecheck/lint/format clean.
