### PR TITLE
Refactor: extract refresh manager + structured observability primitives

### DIFF
--- a/src/auth/api-token-mode.ts
+++ b/src/auth/api-token-mode.ts
@@ -1,11 +1,13 @@
 import { env as cloudflareEnv } from 'cloudflare:workers'
 
+import { createLogger } from '../observability/logger'
 import { getUserAndAccounts } from './oauth-handler'
 import { OAuthError } from './workers-oauth-utils'
 
 import type { AccountSchema, AuthProps, UserSchema } from './types'
 
 const env = cloudflareEnv as Env
+const log = createLogger('api-token-mode')
 const API_TOKEN_IDENTITY_CACHE_TTL_SECONDS = 2_592_000
 
 type ApiTokenIdentity = {
@@ -27,7 +29,7 @@ async function getCachedApiTokenIdentity(token: string): Promise<ApiTokenIdentit
       return cached
     }
   } catch (error) {
-    console.warn('api_token_identity_probe kv-cache read failed', error)
+    log.warn('api_token_identity_probe kv-cache read failed', { error })
   }
 
   const identity = await getUserAndAccounts(token, 'api_token_identity_probe')
@@ -37,7 +39,7 @@ async function getCachedApiTokenIdentity(token: string): Promise<ApiTokenIdentit
       expirationTtl: API_TOKEN_IDENTITY_CACHE_TTL_SECONDS
     })
   } catch (error) {
-    console.warn('api_token_identity_probe kv-cache write failed', error)
+    log.warn('api_token_identity_probe kv-cache write failed', { error })
   }
 
   return identity

--- a/src/auth/cloudflare-auth.ts
+++ b/src/auth/cloudflare-auth.ts
@@ -1,8 +1,12 @@
 import { z } from 'zod'
 
+import { createLogger } from '../observability/logger'
+
 import type { AuthRequest } from '@cloudflare/workers-oauth-provider'
 
 import { OAuthError } from './workers-oauth-utils'
+
+const log = createLogger('cloudflare-auth')
 
 /**
  * Convert an upstream Cloudflare OAuth error response to an OAuthError.
@@ -130,7 +134,7 @@ export async function getAuthToken(params: {
   })
 
   if (!resp.ok) {
-    console.error(`Token exchange failed: ${resp.status}`, await resp.text())
+    log.error('token exchange failed', { status: resp.status, body: await resp.text() })
     throwUpstreamError(resp, 'Token exchange failed')
   }
 
@@ -162,7 +166,7 @@ export async function refreshAuthToken(params: {
   })
 
   if (!resp.ok) {
-    console.error(`Token refresh failed: ${resp.status}`, await resp.text())
+    log.error('token refresh failed', { status: resp.status, body: await resp.text() })
     throwUpstreamError(resp, 'Token refresh failed')
   }
 

--- a/src/auth/oauth-handler.ts
+++ b/src/auth/oauth-handler.ts
@@ -27,7 +27,9 @@ import {
   validateOAuthState,
   OAuthError
 } from './workers-oauth-utils'
+import { refreshManager } from './refresh/refresh-manager'
 import { fetchWithRetry } from '../utils/fetch-retry'
+import { createLogger } from '../observability/logger'
 
 import type {
   AuthRequest,
@@ -41,264 +43,7 @@ interface AuthEnv extends Env {
 }
 
 const env = cloudflareEnv as AuthEnv
-const REFRESH_GUARD_PREFIX = 'oauth:refresh-guard'
-const REFRESH_IN_FLIGHT_TTL_SECONDS = 60
-const REFRESH_FAILURE_TTL_SECONDS = 3600
-const refreshInFlight = new Map<string, Promise<TokenExchangeCallbackResult | undefined>>()
-
-async function sha256Hex(value: string): Promise<string> {
-  const data = new TextEncoder().encode(value)
-  const digest = await crypto.subtle.digest('SHA-256', data)
-  return Array.from(new Uint8Array(digest))
-    .map((byte) => byte.toString(16).padStart(2, '0'))
-    .join('')
-}
-
-function refreshGuardKeys(refreshTokenHash: string): { inFlight: string; failure: string } {
-  return {
-    inFlight: `${REFRESH_GUARD_PREFIX}:${refreshTokenHash}:in-flight`,
-    failure: `${REFRESH_GUARD_PREFIX}:${refreshTokenHash}:failure`
-  }
-}
-
-function isTerminalRefreshError(error: unknown): error is OAuthError {
-  return (
-    error instanceof OAuthError &&
-    ['invalid_grant', 'invalid_client', 'unauthorized_client'].includes(error.code)
-  )
-}
-
-/**
- * Context needed to kill the downstream grant + emit telemetry when an upstream
- * refresh fails. Optional so the guard stays usable in isolation (tests).
- */
-export interface RefreshGuardContext {
-  /** Downstream OAuth user id (from the token-exchange callback options). */
-  userId?: string
-  /** Downstream OAuth client id (from the token-exchange callback options). */
-  clientId?: string
-  /**
-   * Lazily builds OAuth helpers (via `getOAuthApi`). Only invoked on a terminal
-   * `invalid_grant` so we don't construct the provider on every refresh.
-   */
-  getHelpers?: () => OAuthHelpers
-}
-
-type RefreshFailureKind = 'upstream_terminal' | 'cached_replay' | 'in_flight_collision'
-
-/**
- * Structured, greppable telemetry for refresh failures. Logged as a single JSON
- * line prefixed with `[refresh-telemetry]` so it can be counted in Workers Logs.
- *
- * `kind` distinguishes the cases you want to measure:
- *  - `upstream_terminal`: upstream /oauth2/token actually returned a terminal
- *    error this request (the *first-time* failure). `grantsRevoked` tells you
- *    whether we killed the grant.
- *  - `cached_replay`: a retry that short-circuited on the cached failure within
- *    REFRESH_FAILURE_TTL_SECONDS (a *repeat*, never hit upstream).
- *  - `in_flight_collision`: another isolate was mid-refresh.
- */
-function logRefreshTelemetry(event: {
-  kind: RefreshFailureKind
-  code: string
-  refreshTokenHash: string
-  userId?: string
-  clientId?: string
-  grantsRevoked?: number
-}): void {
-  console.error(`[refresh-telemetry] ${JSON.stringify({ ...event, at: Date.now() })}`)
-}
-
-/**
- * Kill every grant for this user+client. `completeAuthorization` revokes prior
- * grants for the same user+client by default, so in practice there is at most
- * one, but we loop defensively (and paginate). `revokeGrant` deletes all access
- * tokens for the grant and the grant record itself, which invalidates the
- * downstream refresh token too.
- */
-async function revokeGrantsForClient(
-  helpers: OAuthHelpers,
-  userId: string,
-  clientId: string
-): Promise<number> {
-  let revoked = 0
-  let cursor: string | undefined
-  do {
-    const page = await helpers.listUserGrants(userId, cursor ? { cursor } : undefined)
-    for (const grant of page.items) {
-      if (grant.clientId !== clientId) continue
-      await helpers.revokeGrant(grant.id, userId)
-      revoked++
-    }
-    cursor = page.cursor
-  } while (cursor)
-  return revoked
-}
-
-async function getCachedRefreshFailure(
-  kv: KVNamespace,
-  failureKey: string
-): Promise<{ code?: string; description?: string } | null> {
-  try {
-    const failure = await kv.get(failureKey, { type: 'json' })
-    if (!failure || typeof failure !== 'object') return null
-    return failure as { code?: string; description?: string }
-  } catch (error) {
-    console.warn('Refresh guard: failed to read cached refresh failure', error)
-    return null
-  }
-}
-
-async function isRefreshInFlight(kv: KVNamespace, inFlightKey: string): Promise<boolean> {
-  try {
-    return Boolean(await kv.get(inFlightKey))
-  } catch (error) {
-    console.warn('Refresh guard: failed to read in-flight marker', error)
-    return false
-  }
-}
-
-async function markRefreshInFlight(kv: KVNamespace, inFlightKey: string): Promise<void> {
-  try {
-    await kv.put(inFlightKey, JSON.stringify({ startedAt: Date.now() }), {
-      expirationTtl: REFRESH_IN_FLIGHT_TTL_SECONDS
-    })
-  } catch (error) {
-    console.warn('Refresh guard: failed to write in-flight marker', error)
-  }
-}
-
-async function cacheRefreshFailure(
-  kv: KVNamespace,
-  failureKey: string,
-  error: OAuthError
-): Promise<void> {
-  try {
-    await kv.put(
-      failureKey,
-      JSON.stringify({
-        code: error.code,
-        description: 'Token refresh failed; reauthorization is required',
-        failedAt: Date.now()
-      }),
-      { expirationTtl: REFRESH_FAILURE_TTL_SECONDS }
-    )
-  } catch (cacheError) {
-    console.warn('Refresh guard: failed to cache terminal refresh failure', cacheError)
-  }
-}
-
-async function clearRefreshInFlight(kv: KVNamespace, inFlightKey: string): Promise<void> {
-  try {
-    await kv.delete(inFlightKey)
-  } catch (error) {
-    console.warn('Refresh guard: failed to clear in-flight marker', error)
-  }
-}
-
-export async function guardRefreshTokenExchange(
-  kv: KVNamespace,
-  refreshToken: string,
-  refresh: () => Promise<TokenExchangeCallbackResult | undefined>,
-  context: RefreshGuardContext = {}
-): Promise<TokenExchangeCallbackResult | undefined> {
-  const refreshTokenHash = await sha256Hex(refreshToken)
-  const keys = refreshGuardKeys(refreshTokenHash)
-  const existingRefresh = refreshInFlight.get(refreshTokenHash)
-  if (existingRefresh) return existingRefresh
-
-  const refreshPromise = (async () => {
-    try {
-      const cachedFailure = await getCachedRefreshFailure(kv, keys.failure)
-      if (cachedFailure) {
-        const code = cachedFailure.code || 'invalid_grant'
-        // A retry of an already-failed token within the cache TTL. The grant was
-        // already killed on the first failure; this never reaches upstream.
-        logRefreshTelemetry({
-          kind: 'cached_replay',
-          code,
-          refreshTokenHash,
-          userId: context.userId,
-          clientId: context.clientId
-        })
-        throw new OAuthError(
-          code,
-          cachedFailure.description || 'Token refresh recently failed; reauthorization is required',
-          400
-        )
-      }
-
-      if (await isRefreshInFlight(kv, keys.inFlight)) {
-        logRefreshTelemetry({
-          kind: 'in_flight_collision',
-          code: 'temporarily_unavailable',
-          refreshTokenHash,
-          userId: context.userId,
-          clientId: context.clientId
-        })
-        throw new OAuthError(
-          'temporarily_unavailable',
-          'Token refresh is already in progress; retry shortly',
-          429,
-          { 'Retry-After': '30' }
-        )
-      }
-
-      await markRefreshInFlight(kv, keys.inFlight)
-
-      try {
-        return await refresh()
-      } catch (error) {
-        if (isTerminalRefreshError(error)) {
-          await cacheRefreshFailure(kv, keys.failure, error)
-
-          // The core fix: when upstream rejects the stored refresh token with
-          // invalid_grant it is permanently dead, so kill the downstream grant
-          // and force re-auth instead of letting the client retry forever.
-          // Other terminal codes (invalid_client/unauthorized_client) are
-          // server-side credential problems that revoking wouldn't fix.
-          let grantsRevoked = 0
-          if (
-            error.code === 'invalid_grant' &&
-            context.userId &&
-            context.clientId &&
-            context.getHelpers
-          ) {
-            try {
-              grantsRevoked = await revokeGrantsForClient(
-                context.getHelpers(),
-                context.userId,
-                context.clientId
-              )
-            } catch (revokeError) {
-              console.error(
-                'Refresh guard: failed to revoke grant after invalid_grant',
-                revokeError
-              )
-            }
-          }
-
-          logRefreshTelemetry({
-            kind: 'upstream_terminal',
-            code: error.code,
-            refreshTokenHash,
-            userId: context.userId,
-            clientId: context.clientId,
-            grantsRevoked
-          })
-        }
-        throw error
-      } finally {
-        await clearRefreshInFlight(kv, keys.inFlight)
-      }
-    } finally {
-      refreshInFlight.delete(refreshTokenHash)
-    }
-  })()
-
-  refreshInFlight.set(refreshTokenHash, refreshPromise)
-  return refreshPromise
-}
+const log = createLogger('oauth-handler')
 
 function getRetryAfterHeader(...responses: Response[]): Record<string, string> {
   return {
@@ -343,7 +88,7 @@ async function fetchCloudflareProbes(
       fetchWithRetry(`${env.CLOUDFLARE_API_BASE}/accounts`, { headers }, { caller })
     ])
   } catch (error) {
-    console.error('Cloudflare API request failed', error)
+    log.error('Cloudflare API request failed', { error })
     throw new OAuthError('server_error', 'Cloudflare API is temporarily unavailable', 502)
   }
 }
@@ -362,7 +107,10 @@ export async function getUserAndAccounts(
 
   // Check for upstream errors before parsing
   if (!userResp.ok && !accountsResp.ok) {
-    console.error(`Cloudflare API error: user=${userResp.status}, accounts=${accountsResp.status}`)
+    log.error('Cloudflare API error', {
+      userStatus: userResp.status,
+      accountsStatus: accountsResp.status
+    })
     throwCombinedCloudflareApiError(userResp, accountsResp)
   }
 
@@ -376,11 +124,13 @@ export async function getUserAndAccounts(
         if (parsed.success) {
           user = parsed.data
         } else {
-          console.error('Cloudflare API /user payload did not match expected shape', parsed.error)
+          log.error('Cloudflare API /user payload did not match expected shape', {
+            error: parsed.error
+          })
         }
       }
     } catch (error) {
-      console.error('Cloudflare API /user response is not valid JSON', error)
+      log.error('Cloudflare API /user response is not valid JSON', { error })
     }
   }
 
@@ -394,14 +144,13 @@ export async function getUserAndAccounts(
         if (parsed.success) {
           accounts = parsed.data
         } else {
-          console.error(
-            'Cloudflare API /accounts payload did not match expected shape',
-            parsed.error
-          )
+          log.error('Cloudflare API /accounts payload did not match expected shape', {
+            error: parsed.error
+          })
         }
       }
     } catch (error) {
-      console.error('Cloudflare API /accounts response is not valid JSON', error)
+      log.error('Cloudflare API /accounts response is not valid JSON', { error })
     }
   }
 
@@ -467,7 +216,7 @@ export async function handleTokenExchangeCallback(
 
   const upstreamRefreshToken = props.refreshToken
 
-  return guardRefreshTokenExchange(
+  return refreshManager.run(
     env.OAUTH_KV,
     upstreamRefreshToken,
     async () => {
@@ -593,7 +342,7 @@ export function createAuthHandlers() {
     } catch (e) {
       if (e instanceof OAuthError) return e.toHtmlResponse()
       const errorId = crypto.randomUUID()
-      console.error(`Authorize error [${errorId}]:`, e)
+      log.error('Authorize error', { errorId, error: e })
       return renderErrorPage(
         'Server Error',
         'An unexpected error occurred. Please try again.',
@@ -648,7 +397,7 @@ export function createAuthHandlers() {
     } catch (e) {
       if (e instanceof OAuthError) return e.toHtmlResponse()
       const errorId = crypto.randomUUID()
-      console.error(`Authorize POST error [${errorId}]:`, e)
+      log.error('Authorize POST error', { errorId, error: e })
       return renderErrorPage(
         'Server Error',
         'An unexpected error occurred. Please try again.',
@@ -729,7 +478,7 @@ export function createAuthHandlers() {
     } catch (e) {
       if (e instanceof OAuthError) return e.toHtmlResponse()
       const errorId = crypto.randomUUID()
-      console.error(`Callback error [${errorId}]:`, e)
+      log.error('Callback error', { errorId, error: e })
       return renderErrorPage(
         'Server Error',
         'An unexpected error occurred during authorization.',

--- a/src/auth/refresh/refresh-errors.ts
+++ b/src/auth/refresh/refresh-errors.ts
@@ -1,0 +1,24 @@
+import { OAuthError } from '../workers-oauth-utils'
+
+/**
+ * Terminal refresh errors: the upstream refused the refresh in a way that won't
+ * succeed on retry, so we cache the failure to stop hammering upstream.
+ */
+const TERMINAL_REFRESH_CODES = ['invalid_grant', 'invalid_client', 'unauthorized_client']
+
+export function isTerminalRefreshError(error: unknown): error is OAuthError {
+  return error instanceof OAuthError && TERMINAL_REFRESH_CODES.includes(error.code)
+}
+
+/**
+ * Whether a terminal failure means the stored upstream refresh token is
+ * permanently dead and the downstream grant should be killed to force re-auth.
+ *
+ * Only `invalid_grant` qualifies — the refresh token itself was rejected.
+ * `invalid_client` / `unauthorized_client` are server-side credential/config
+ * problems where revoking the user's grant would be pointless (re-auth wouldn't
+ * fix bad client credentials).
+ */
+export function shouldRevokeGrant(error: OAuthError): boolean {
+  return error.code === 'invalid_grant'
+}

--- a/src/auth/refresh/refresh-manager.ts
+++ b/src/auth/refresh/refresh-manager.ts
@@ -1,0 +1,187 @@
+import type { OAuthHelpers, TokenExchangeCallbackResult } from '@cloudflare/workers-oauth-provider'
+
+import { createLogger } from '../../observability/logger'
+import { createTelemetry } from '../../observability/telemetry'
+import { OAuthError } from '../workers-oauth-utils'
+import { isTerminalRefreshError, shouldRevokeGrant } from './refresh-errors'
+import { RefreshStore } from './refresh-store'
+
+const log = createLogger('refresh-manager')
+
+/**
+ * Refresh outcome telemetry. One event per guarded refresh that fails; greppable
+ * as `[refresh-telemetry] {...}` in Workers Logs.
+ *
+ *  - `upstream_terminal`: upstream actually returned a terminal error this
+ *    request (the *first-time* failure). `grantsRevoked` reports whether we
+ *    killed the dead grant.
+ *  - `cached_replay`: a retry short-circuited on the cached failure (a *repeat*,
+ *    never hit upstream).
+ *  - `in_flight_collision`: another isolate was mid-refresh.
+ */
+interface RefreshTelemetryEvent {
+  kind: 'upstream_terminal' | 'cached_replay' | 'in_flight_collision'
+  code: string
+  refreshTokenHash: string
+  userId?: string
+  clientId?: string
+  grantsRevoked?: number
+}
+
+const refreshTelemetry = createTelemetry<RefreshTelemetryEvent>('refresh-telemetry')
+
+/**
+ * Identifies the downstream grant so we can revoke it when the upstream refresh
+ * token is permanently dead. `getHelpers` is lazy — only invoked on a terminal
+ * `invalid_grant` — because `env.OAUTH_PROVIDER` is not injected during the
+ * token endpoint, so helpers must be constructed on demand via `getOAuthApi`.
+ */
+export interface RefreshContext {
+  userId?: string
+  clientId?: string
+  getHelpers?: () => OAuthHelpers
+}
+
+/** The actual upstream token exchange; provided by the caller. */
+export type PerformRefresh = () => Promise<TokenExchangeCallbackResult | undefined>
+
+/**
+ * Guards and instruments the upstream refresh-token exchange.
+ *
+ * Responsibilities, in one place:
+ *  - **Singleflight**: dedupe concurrent refreshes of the same token within an
+ *    isolate (in-memory) and across isolates (KV in-flight marker).
+ *  - **Fail-fast**: short-circuit retries of a token that recently failed.
+ *  - **Revoke**: on `invalid_grant`, kill the dead downstream grant so the
+ *    client is forced to re-authorize instead of looping forever.
+ *  - **Telemetry**: emit a structured event for every failure mode.
+ *
+ * Behavior is identical to the previous inline `guardRefreshTokenExchange`; this
+ * just gives the refresh lifecycle a cohesive home.
+ */
+class RefreshManager {
+  /** In-isolate singleflight: collapse concurrent refreshes of the same token. */
+  private readonly inFlight = new Map<string, Promise<TokenExchangeCallbackResult | undefined>>()
+
+  async run(
+    kv: KVNamespace,
+    refreshToken: string,
+    perform: PerformRefresh,
+    context: RefreshContext = {}
+  ): Promise<TokenExchangeCallbackResult | undefined> {
+    const store = await RefreshStore.forToken(kv, refreshToken)
+    const existing = this.inFlight.get(store.tokenHash)
+    if (existing) return existing
+
+    const promise = this.guard(store, perform, context).finally(() => {
+      this.inFlight.delete(store.tokenHash)
+    })
+    this.inFlight.set(store.tokenHash, promise)
+    return promise
+  }
+
+  private async guard(
+    store: RefreshStore,
+    perform: PerformRefresh,
+    context: RefreshContext
+  ): Promise<TokenExchangeCallbackResult | undefined> {
+    const cachedFailure = await store.getCachedFailure()
+    if (cachedFailure) {
+      const code = cachedFailure.code || 'invalid_grant'
+      // Retry of an already-failed token within the cache TTL. The grant was
+      // already killed on the first failure; this never reaches upstream.
+      this.emit('cached_replay', code, store, context)
+      throw new OAuthError(
+        code,
+        cachedFailure.description || 'Token refresh recently failed; reauthorization is required',
+        400
+      )
+    }
+
+    if (await store.isInFlight()) {
+      this.emit('in_flight_collision', 'temporarily_unavailable', store, context)
+      throw new OAuthError(
+        'temporarily_unavailable',
+        'Token refresh is already in progress; retry shortly',
+        429,
+        { 'Retry-After': '30' }
+      )
+    }
+
+    await store.markInFlight()
+    try {
+      return await perform()
+    } catch (error) {
+      if (isTerminalRefreshError(error)) {
+        await store.cacheFailure(error)
+        const grantsRevoked = await this.maybeRevoke(error, context)
+        this.emit('upstream_terminal', error.code, store, context, grantsRevoked)
+      }
+      throw error
+    } finally {
+      await store.clearInFlight()
+    }
+  }
+
+  /**
+   * Kill the dead downstream grant on `invalid_grant`. Returns the number of
+   * grants revoked (0 if not applicable or revocation failed).
+   */
+  private async maybeRevoke(error: OAuthError, context: RefreshContext): Promise<number> {
+    if (!shouldRevokeGrant(error) || !context.userId || !context.clientId || !context.getHelpers) {
+      return 0
+    }
+    try {
+      return await revokeGrantsForClient(context.getHelpers(), context.userId, context.clientId)
+    } catch (revokeError) {
+      log.error('failed to revoke grant after invalid_grant', { error: revokeError })
+      return 0
+    }
+  }
+
+  private emit(
+    kind: RefreshTelemetryEvent['kind'],
+    code: string,
+    store: RefreshStore,
+    context: RefreshContext,
+    grantsRevoked?: number
+  ): void {
+    refreshTelemetry({
+      kind,
+      code,
+      refreshTokenHash: store.tokenHash,
+      userId: context.userId,
+      clientId: context.clientId,
+      ...(grantsRevoked !== undefined ? { grantsRevoked } : {})
+    })
+  }
+}
+
+/**
+ * Revoke every grant for this user+client. `completeAuthorization` revokes prior
+ * grants for the same user+client by default, so in practice there is at most
+ * one, but we loop defensively (and paginate). `revokeGrant` deletes all access
+ * tokens for the grant and the grant record itself, invalidating the downstream
+ * refresh token too.
+ */
+async function revokeGrantsForClient(
+  helpers: OAuthHelpers,
+  userId: string,
+  clientId: string
+): Promise<number> {
+  let revoked = 0
+  let cursor: string | undefined
+  do {
+    const page = await helpers.listUserGrants(userId, cursor ? { cursor } : undefined)
+    for (const grant of page.items) {
+      if (grant.clientId !== clientId) continue
+      await helpers.revokeGrant(grant.id, userId)
+      revoked++
+    }
+    cursor = page.cursor
+  } while (cursor)
+  return revoked
+}
+
+/** Process-wide singleton so the in-isolate singleflight map is shared. */
+export const refreshManager = new RefreshManager()

--- a/src/auth/refresh/refresh-manager.ts
+++ b/src/auth/refresh/refresh-manager.ts
@@ -26,6 +26,14 @@ interface RefreshTelemetryEvent {
   userId?: string
   clientId?: string
   grantsRevoked?: number
+  /**
+   * `createdAt` (epoch seconds) of the revoked grant, and its age at failure.
+   * Lets us tell whether failing refreshes are recently-issued grants (a real
+   * bug) or old pre-fix grants draining out (expected). When multiple grants
+   * are revoked, this is the oldest.
+   */
+  revokedGrantCreatedAt?: number
+  revokedGrantAgeSec?: number
 }
 
 const refreshTelemetry = createTelemetry<RefreshTelemetryEvent>('refresh-telemetry')
@@ -114,8 +122,8 @@ class RefreshManager {
     } catch (error) {
       if (isTerminalRefreshError(error)) {
         await store.cacheFailure(error)
-        const grantsRevoked = await this.maybeRevoke(error, context)
-        this.emit('upstream_terminal', error.code, store, context, grantsRevoked)
+        const revoked = await this.maybeRevoke(error, context)
+        this.emit('upstream_terminal', error.code, store, context, revoked)
       }
       throw error
     } finally {
@@ -124,18 +132,19 @@ class RefreshManager {
   }
 
   /**
-   * Kill the dead downstream grant on `invalid_grant`. Returns the number of
-   * grants revoked (0 if not applicable or revocation failed).
+   * Kill the dead downstream grant on `invalid_grant`. Returns the revoke count
+   * and the oldest revoked grant's `createdAt` (for age telemetry), or an empty
+   * result if not applicable / revocation failed.
    */
-  private async maybeRevoke(error: OAuthError, context: RefreshContext): Promise<number> {
+  private async maybeRevoke(error: OAuthError, context: RefreshContext): Promise<RevokeResult> {
     if (!shouldRevokeGrant(error) || !context.userId || !context.clientId || !context.getHelpers) {
-      return 0
+      return { count: 0 }
     }
     try {
       return await revokeGrantsForClient(context.getHelpers(), context.userId, context.clientId)
     } catch (revokeError) {
       log.error('failed to revoke grant after invalid_grant', { error: revokeError })
-      return 0
+      return { count: 0 }
     }
   }
 
@@ -144,15 +153,23 @@ class RefreshManager {
     code: string,
     store: RefreshStore,
     context: RefreshContext,
-    grantsRevoked?: number
+    revoked?: RevokeResult
   ): void {
+    const ageFields =
+      revoked?.oldestCreatedAt !== undefined
+        ? {
+            revokedGrantCreatedAt: revoked.oldestCreatedAt,
+            revokedGrantAgeSec: Math.floor(Date.now() / 1000) - revoked.oldestCreatedAt
+          }
+        : {}
     refreshTelemetry({
       kind,
       code,
       refreshTokenHash: store.tokenHash,
       userId: context.userId,
       clientId: context.clientId,
-      ...(grantsRevoked !== undefined ? { grantsRevoked } : {})
+      ...(revoked !== undefined ? { grantsRevoked: revoked.count } : {}),
+      ...ageFields
     })
   }
 }
@@ -164,23 +181,36 @@ class RefreshManager {
  * tokens for the grant and the grant record itself, invalidating the downstream
  * refresh token too.
  */
+interface RevokeResult {
+  count: number
+  /** Oldest `createdAt` (epoch seconds) among revoked grants, if any. */
+  oldestCreatedAt?: number
+}
+
 async function revokeGrantsForClient(
   helpers: OAuthHelpers,
   userId: string,
   clientId: string
-): Promise<number> {
-  let revoked = 0
+): Promise<RevokeResult> {
+  let count = 0
+  let oldestCreatedAt: number | undefined
   let cursor: string | undefined
   do {
     const page = await helpers.listUserGrants(userId, cursor ? { cursor } : undefined)
     for (const grant of page.items) {
       if (grant.clientId !== clientId) continue
+      if (grant.createdAt !== undefined) {
+        oldestCreatedAt =
+          oldestCreatedAt === undefined
+            ? grant.createdAt
+            : Math.min(oldestCreatedAt, grant.createdAt)
+      }
       await helpers.revokeGrant(grant.id, userId)
-      revoked++
+      count++
     }
     cursor = page.cursor
   } while (cursor)
-  return revoked
+  return { count, oldestCreatedAt }
 }
 
 /** Process-wide singleton so the in-isolate singleflight map is shared. */

--- a/src/auth/refresh/refresh-store.ts
+++ b/src/auth/refresh/refresh-store.ts
@@ -1,0 +1,112 @@
+import { createLogger } from '../../observability/logger'
+import { OAuthError } from '../workers-oauth-utils'
+
+const log = createLogger('refresh-store')
+
+/**
+ * KV-backed state for the refresh guard, keyed by a hash of the upstream
+ * refresh token. Two records per token:
+ *  - `in-flight`: a short-lived marker that another isolate is mid-refresh.
+ *  - `failure`:   a cached terminal failure so retries fail fast without
+ *                 re-hitting upstream.
+ *
+ * All operations are best-effort: KV hiccups must never turn a recoverable
+ * refresh into a hard failure, so reads degrade to "absent" and writes are
+ * swallowed (with a warning).
+ */
+const GUARD_PREFIX = 'oauth:refresh-guard'
+const IN_FLIGHT_TTL_SECONDS = 60
+// Short on purpose. The cached failure only needs to cover the brief window
+// where a retry could still hit upstream before suppression takes hold:
+//  - the KV eventual-consistency lag after we revoke the dead grant, and
+//  - the upstream OAuth server's ~1 min refresh coalescing grace window.
+// Permanent loop-prevention is owned by grant revocation (on invalid_grant),
+// not by this cache, so it no longer needs a long (1h) TTL.
+const FAILURE_TTL_SECONDS = 120
+
+export interface CachedRefreshFailure {
+  code?: string
+  description?: string
+}
+
+async function sha256Hex(value: string): Promise<string> {
+  const data = new TextEncoder().encode(value)
+  const digest = await crypto.subtle.digest('SHA-256', data)
+  return Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('')
+}
+
+export class RefreshStore {
+  private constructor(
+    private readonly kv: KVNamespace,
+    readonly tokenHash: string
+  ) {}
+
+  /** Build a store scoped to one upstream refresh token (hashes it for keys). */
+  static async forToken(kv: KVNamespace, refreshToken: string): Promise<RefreshStore> {
+    return new RefreshStore(kv, await sha256Hex(refreshToken))
+  }
+
+  private get inFlightKey(): string {
+    return `${GUARD_PREFIX}:${this.tokenHash}:in-flight`
+  }
+
+  private get failureKey(): string {
+    return `${GUARD_PREFIX}:${this.tokenHash}:failure`
+  }
+
+  async getCachedFailure(): Promise<CachedRefreshFailure | null> {
+    try {
+      const failure = await this.kv.get(this.failureKey, { type: 'json' })
+      if (!failure || typeof failure !== 'object') return null
+      return failure as CachedRefreshFailure
+    } catch (error) {
+      log.warn('failed to read cached refresh failure', { error })
+      return null
+    }
+  }
+
+  async cacheFailure(error: OAuthError): Promise<void> {
+    try {
+      await this.kv.put(
+        this.failureKey,
+        JSON.stringify({
+          code: error.code,
+          description: 'Token refresh failed; reauthorization is required',
+          failedAt: Date.now()
+        }),
+        { expirationTtl: FAILURE_TTL_SECONDS }
+      )
+    } catch (error) {
+      log.warn('failed to cache terminal refresh failure', { error })
+    }
+  }
+
+  async isInFlight(): Promise<boolean> {
+    try {
+      return Boolean(await this.kv.get(this.inFlightKey))
+    } catch (error) {
+      log.warn('failed to read in-flight marker', { error })
+      return false
+    }
+  }
+
+  async markInFlight(): Promise<void> {
+    try {
+      await this.kv.put(this.inFlightKey, JSON.stringify({ startedAt: Date.now() }), {
+        expirationTtl: IN_FLIGHT_TTL_SECONDS
+      })
+    } catch (error) {
+      log.warn('failed to write in-flight marker', { error })
+    }
+  }
+
+  async clearInFlight(): Promise<void> {
+    try {
+      await this.kv.delete(this.inFlightKey)
+    } catch (error) {
+      log.warn('failed to clear in-flight marker', { error })
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,10 @@ import { createAuthHandlers, handleTokenExchangeCallback } from './auth/oauth-ha
 import { isDirectApiToken, handleApiTokenRequest } from './auth/api-token-mode'
 import { processSpec, extractProducts } from './spec-processor'
 import { fetchWithRetry } from './utils/fetch-retry'
+import { createLogger } from './observability/logger'
 import type { AuthProps } from './auth/types'
+
+const log = createLogger('spec-sync')
 
 /**
  * Global outbound fetch handler that restricts dynamically-loaded workers
@@ -137,7 +140,7 @@ export default {
     env: Env,
     _ctx: ExecutionContext
   ): Promise<void> {
-    console.log('Fetching OpenAPI spec from:', env.OPENAPI_SPEC_URL)
+    log.info('Fetching OpenAPI spec', { url: env.OPENAPI_SPEC_URL })
 
     const response = await fetch(env.OPENAPI_SPEC_URL)
     if (!response.ok) {
@@ -145,7 +148,7 @@ export default {
     }
 
     const rawSpec = (await response.json()) as Record<string, unknown>
-    console.log('Processing spec, resolving $refs...')
+    log.info('Processing spec, resolving $refs')
 
     const processed = processSpec(rawSpec)
     const specJson = JSON.stringify(processed)
@@ -153,7 +156,7 @@ export default {
     const products = extractProducts(rawSpec)
     const productsJson = JSON.stringify(products)
 
-    console.log(`Writing spec to R2 (${(specJson.length / 1024).toFixed(0)} KB)`)
+    log.info('Writing spec to R2', { sizeKb: Number((specJson.length / 1024).toFixed(0)) })
     await Promise.all([
       env.SPEC_BUCKET.put('spec.json', specJson, {
         httpMetadata: { contentType: 'application/json' }
@@ -163,6 +166,6 @@ export default {
       })
     ])
 
-    console.log(`Spec updated successfully (${products.length} products)`)
+    log.info('Spec updated successfully', { productCount: products.length })
   }
 }

--- a/src/observability/logger.ts
+++ b/src/observability/logger.ts
@@ -1,0 +1,50 @@
+/**
+ * Structured diagnostic logging primitive.
+ *
+ * The companion to {@link createTelemetry}. Telemetry is for countable domain
+ * events; this is for leveled diagnostics (a recoverable KV miss, an upstream
+ * error, an unexpected exception). Both emit the same greppable
+ * `[<channel>] {json}` shape so a single log pipeline can parse everything.
+ *
+ * Rules of thumb:
+ *  - Reach for a **telemetry channel** when you want to *count* something
+ *    (refresh outcomes, cache hits) — stable `kind` field, no free text.
+ *  - Reach for a **logger** when you want to *describe* something that went
+ *    wrong, with a human message and structured context.
+ *
+ * `Error` values in `fields` are serialized to `{ name, message, stack }`
+ * (plain `JSON.stringify` would drop them to `{}`).
+ *
+ * @example
+ * const log = createLogger('oauth-handler')
+ * log.warn('failed to read cached refresh failure', { error })
+ * // [oauth-handler] {"level":"warn","message":"failed to read cached refresh failure","error":{...},"at":...}
+ */
+export type LogLevel = 'info' | 'warn' | 'error'
+
+export interface Logger {
+  info(message: string, fields?: Record<string, unknown>): void
+  warn(message: string, fields?: Record<string, unknown>): void
+  error(message: string, fields?: Record<string, unknown>): void
+}
+
+function serializeErrors(_key: string, value: unknown): unknown {
+  if (value instanceof Error) {
+    return { name: value.name, message: value.message, stack: value.stack }
+  }
+  return value
+}
+
+export function createLogger(channel: string): Logger {
+  const emit = (level: LogLevel, message: string, fields?: Record<string, unknown>): void => {
+    const line = JSON.stringify({ level, message, ...fields, at: Date.now() }, serializeErrors)
+    const sink = level === 'error' ? console.error : level === 'warn' ? console.warn : console.log
+    sink(`[${channel}] ${line}`)
+  }
+
+  return {
+    info: (message, fields) => emit('info', message, fields),
+    warn: (message, fields) => emit('warn', message, fields),
+    error: (message, fields) => emit('error', message, fields)
+  }
+}

--- a/src/observability/telemetry.ts
+++ b/src/observability/telemetry.ts
@@ -1,0 +1,25 @@
+/**
+ * Structured telemetry primitive.
+ *
+ * Emits one JSON line per event, prefixed with `[<channel>]`, so events are
+ * greppable and countable in Workers Logs (and any log sink) without a metrics
+ * backend. A timestamp (`at`, epoch ms) is attached automatically.
+ *
+ * This is the canonical pattern for structured diagnostics in this worker:
+ * declare a typed event shape, create a channel once, and call it. Prefer this
+ * over ad-hoc `console.log(JSON.stringify(...))` so every subsystem emits a
+ * consistent, parseable format.
+ *
+ * @example
+ * interface RefreshEvent { kind: 'upstream_terminal' | 'cached_replay'; code: string }
+ * const refreshTelemetry = createTelemetry<RefreshEvent>('refresh-telemetry')
+ * refreshTelemetry({ kind: 'upstream_terminal', code: 'invalid_grant' })
+ * // logs: [refresh-telemetry] {"kind":"upstream_terminal","code":"invalid_grant","at":1780000000000}
+ */
+export type TelemetryEmitter<E extends object> = (event: E) => void
+
+export function createTelemetry<E extends object>(channel: string): TelemetryEmitter<E> {
+  return (event: E) => {
+    console.log(`[${channel}] ${JSON.stringify({ ...event, at: Date.now() })}`)
+  }
+}

--- a/src/tests/auth/oauth-handler.test.ts
+++ b/src/tests/auth/oauth-handler.test.ts
@@ -1,11 +1,8 @@
 import { OAuthError as ProviderOAuthError } from '@cloudflare/workers-oauth-provider'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import {
-  getUserAndAccounts,
-  guardRefreshTokenExchange,
-  handleTokenExchangeCallback
-} from '../../auth/oauth-handler'
+import { getUserAndAccounts, handleTokenExchangeCallback } from '../../auth/oauth-handler'
+import { refreshManager } from '../../auth/refresh/refresh-manager'
 import { OAuthError } from '../../auth/workers-oauth-utils'
 
 import type { AuthorizationToken } from '../../auth/cloudflare-auth'
@@ -353,14 +350,14 @@ describe('getUserAndAccounts', () => {
   })
 })
 
-describe('guardRefreshTokenExchange', () => {
+describe('refreshManager.run', () => {
   it('singleflights concurrent refreshes for the same upstream token in one isolate', async () => {
     const kv = mockKV()
     const refresh = deferred<{ accessTokenTTL: number }>()
     const refreshFn = vi.fn(() => refresh.promise)
 
-    const first = guardRefreshTokenExchange(kv, 'upstream-refresh-token', refreshFn)
-    const second = guardRefreshTokenExchange(kv, 'upstream-refresh-token', refreshFn)
+    const first = refreshManager.run(kv, 'upstream-refresh-token', refreshFn)
+    const second = refreshManager.run(kv, 'upstream-refresh-token', refreshFn)
 
     await vi.waitFor(() => expect(refreshFn).toHaveBeenCalledTimes(1))
 
@@ -379,12 +376,12 @@ describe('guardRefreshTokenExchange', () => {
       .mockRejectedValueOnce(new OAuthError('invalid_grant', 'refresh token reused', 400))
 
     await expectOAuthError(
-      guardRefreshTokenExchange(kv, 'reused-refresh-token', refreshFn),
+      refreshManager.run(kv, 'reused-refresh-token', refreshFn),
       'invalid_grant',
       400
     )
     await expectOAuthError(
-      guardRefreshTokenExchange(kv, 'reused-refresh-token', refreshFn),
+      refreshManager.run(kv, 'reused-refresh-token', refreshFn),
       'invalid_grant',
       400
     )
@@ -401,7 +398,7 @@ describe('guardRefreshTokenExchange', () => {
     const refreshFn = vi.fn()
 
     await expectOAuthError(
-      guardRefreshTokenExchange(kv, refreshToken, refreshFn),
+      refreshManager.run(kv, refreshToken, refreshFn),
       'temporarily_unavailable',
       429
     )
@@ -414,9 +411,7 @@ describe('guardRefreshTokenExchange', () => {
     const refreshFn = vi.fn().mockResolvedValue({ accessTokenTTL: 3600 })
     vi.mocked(kv.delete).mockRejectedValueOnce(new Error('KV delete failed'))
 
-    await expect(
-      guardRefreshTokenExchange(kv, 'cleanup-failure-token', refreshFn)
-    ).resolves.toEqual({
+    await expect(refreshManager.run(kv, 'cleanup-failure-token', refreshFn)).resolves.toEqual({
       accessTokenTTL: 3600
     })
     expect(refreshFn).toHaveBeenCalledTimes(1)
@@ -432,7 +427,7 @@ describe('guardRefreshTokenExchange', () => {
       .mockRejectedValueOnce(new Error('KV put failed'))
 
     await expectOAuthError(
-      guardRefreshTokenExchange(kv, 'failure-cache-error-token', refreshFn),
+      refreshManager.run(kv, 'failure-cache-error-token', refreshFn),
       'invalid_grant',
       400
     )
@@ -451,7 +446,7 @@ describe('guardRefreshTokenExchange', () => {
     const getHelpers = vi.fn(() => helpers)
 
     await expectOAuthError(
-      guardRefreshTokenExchange(kv, 'dead-token', refreshFn, {
+      refreshManager.run(kv, 'dead-token', refreshFn, {
         userId: 'user-1',
         clientId: 'mcp-client',
         getHelpers
@@ -477,7 +472,7 @@ describe('guardRefreshTokenExchange', () => {
     const getHelpers = vi.fn(() => helpers)
 
     await expectOAuthError(
-      guardRefreshTokenExchange(kv, 'transient-token', refreshFn, {
+      refreshManager.run(kv, 'transient-token', refreshFn, {
         userId: 'user-1',
         clientId: 'mcp-client',
         getHelpers
@@ -499,7 +494,7 @@ describe('guardRefreshTokenExchange', () => {
     const getHelpers = vi.fn(() => helpers)
 
     await expectOAuthError(
-      guardRefreshTokenExchange(kv, 'bad-client-token', refreshFn, {
+      refreshManager.run(kv, 'bad-client-token', refreshFn, {
         userId: 'user-1',
         clientId: 'mcp-client',
         getHelpers
@@ -523,7 +518,7 @@ describe('guardRefreshTokenExchange', () => {
     vi.mocked(helpers.revokeGrant).mockRejectedValueOnce(new Error('KV unavailable'))
 
     await expectOAuthError(
-      guardRefreshTokenExchange(kv, 'dead-token-revoke-fails', refreshFn, {
+      refreshManager.run(kv, 'dead-token-revoke-fails', refreshFn, {
         userId: 'user-1',
         clientId: 'mcp-client',
         getHelpers: () => helpers
@@ -550,7 +545,7 @@ describe('guardRefreshTokenExchange', () => {
       } as never)
 
     await expectOAuthError(
-      guardRefreshTokenExchange(kv, 'paginated-token', refreshFn, {
+      refreshManager.run(kv, 'paginated-token', refreshFn, {
         userId: 'user-1',
         clientId: 'mcp-client',
         getHelpers: () => helpers

--- a/src/tests/fetch-retry.test.ts
+++ b/src/tests/fetch-retry.test.ts
@@ -102,7 +102,9 @@ describe('fetchWithRetry', () => {
 
     expect(result.status).toBe(200)
     expect(warnSpy).toHaveBeenCalledWith(
-      'fetchWithRetry: 429 caller=oauth_callback_identity_probe url=https://api.example.com/accounts on attempt 1/2, retrying in 1ms'
+      expect.stringMatching(
+        /^\[fetch-retry\] .*"message":"Received 429, retrying".*"caller":"oauth_callback_identity_probe".*"url":"https:\/\/api\.example\.com\/accounts".*"attempt":1,"maxAttempts":2,"delayMs":1/
+      )
     )
   })
 
@@ -133,7 +135,9 @@ describe('fetchWithRetry', () => {
 
     expect(result.status).toBe(429)
     expect(errorSpy).toHaveBeenCalledWith(
-      'fetchWithRetry: failed url=https://api.example.com/accounts after 1 attempts with status 429'
+      expect.stringMatching(
+        /^\[fetch-retry\] .*"message":"Request failed after all attempts".*"url":"https:\/\/api\.example\.com\/accounts".*"attempts":1,"status":429/
+      )
     )
   })
 
@@ -181,8 +185,9 @@ describe('fetchWithRetry', () => {
     ).rejects.toThrow('network failure')
 
     expect(errorSpy).toHaveBeenCalledWith(
-      'fetchWithRetry: failed url=https://api.example.com/accounts after 1 attempts',
-      error
+      expect.stringMatching(
+        /^\[fetch-retry\] .*"message":"Request failed after all attempts".*"url":"https:\/\/api\.example\.com\/accounts".*"attempts":1.*"error":\{.*"message":"network failure"/
+      )
     )
   })
 

--- a/src/utils/fetch-retry.ts
+++ b/src/utils/fetch-retry.ts
@@ -1,3 +1,7 @@
+import { createLogger } from '../observability/logger'
+
+const log = createLogger('fetch-retry')
+
 export interface RetryOptions {
   maxRetries?: number
   baseDelayMs?: number
@@ -41,7 +45,7 @@ export async function fetchWithRetry(
 ): Promise<Response> {
   const opts = { ...DEFAULT_OPTIONS, ...options }
   const url = typeof input === 'string' ? input : input.url
-  const caller = options?.caller ? ` caller=${options.caller}` : ''
+  const caller = options?.caller
 
   let lastResponse: Response | undefined
   let lastError: unknown
@@ -58,10 +62,13 @@ export async function fetchWithRetry(
 
       if (attempt < opts.maxRetries) {
         const delay = computeRetryDelay(attempt, opts, response.headers.get('Retry-After'))
-        console.warn(
-          `fetchWithRetry: 429${caller} url=${url} on attempt ${attempt + 1}/${opts.maxRetries + 1}, ` +
-            `retrying in ${Math.round(delay)}ms`
-        )
+        log.warn('Received 429, retrying', {
+          caller,
+          url,
+          attempt: attempt + 1,
+          maxAttempts: opts.maxRetries + 1,
+          delayMs: Math.round(delay)
+        })
         await sleep(delay)
       }
     } catch (error) {
@@ -69,26 +76,35 @@ export async function fetchWithRetry(
 
       if (attempt < opts.maxRetries) {
         const delay = computeRetryDelay(attempt, opts, null)
-        console.warn(
-          `fetchWithRetry: network error${caller} url=${url} on attempt ${attempt + 1}/${opts.maxRetries + 1}, ` +
-            `retrying in ${Math.round(delay)}ms: ${error instanceof Error ? error.message : error}`
-        )
+        log.warn('Network error, retrying', {
+          caller,
+          url,
+          attempt: attempt + 1,
+          maxAttempts: opts.maxRetries + 1,
+          delayMs: Math.round(delay),
+          error
+        })
         await sleep(delay)
       }
     }
   }
 
   if (lastResponse) {
-    console.error(
-      `fetchWithRetry: failed${caller} url=${url} after ${opts.maxRetries + 1} attempts with status ${lastResponse.status}`
-    )
+    log.error('Request failed after all attempts', {
+      caller,
+      url,
+      attempts: opts.maxRetries + 1,
+      status: lastResponse.status
+    })
     return lastResponse
   }
 
-  console.error(
-    `fetchWithRetry: failed${caller} url=${url} after ${opts.maxRetries + 1} attempts`,
-    lastError
-  )
+  log.error('Request failed after all attempts', {
+    caller,
+    url,
+    attempts: opts.maxRetries + 1,
+    error: lastError
+  })
   throw lastError
 }
 


### PR DESCRIPTION
> Follow-up to #137 (`Revoke grant on upstream invalid_grant`), now merged. This builds on it and is standalone on `main`.

## What

Two goals: (1) give the token-refresh logic a cohesive home with clear separation of concerns, and (2) establish reusable structured **logging/telemetry primitives** the rest of the worker can adopt.

### New observability primitives (the reusable pattern)
- **`src/observability/telemetry.ts`** — `createTelemetry<E>(channel)` for *countable* domain events. Emits one greppable `[channel] {json}` line with an auto `at` timestamp. (The existing `[refresh-telemetry]` monitoring queries keep working unchanged.)
- **`src/observability/logger.ts`** — `createLogger(channel)` for *leveled* diagnostics (`info`/`warn`/`error`), same `[channel] {json}` shape. `Error` values are serialized to `{name,message,stack}` instead of being dropped to `{}`.

Rule of thumb: **telemetry** to count a domain event (stable `kind`, no free text); **logger** to describe something that went wrong with context.

### Refresh lifecycle extracted from `oauth-handler.ts` (−260 net lines there)
- **`refresh/refresh-manager.ts`** — orchestrates singleflight (in-isolate + KV), fail-fast on cached failure, revoke-on-`invalid_grant`, and telemetry. `oauth-handler` now just calls `refreshManager.run(...)`.
- **`refresh/refresh-store.ts`** — KV state (in-flight marker + cached failure), best-effort with structured logging.
- **`refresh/refresh-errors.ts`** — terminal-error classification (`isTerminalRefreshError`, `shouldRevokeGrant`).

### Full migration to the standard
All 21 remaining raw `console.*` calls migrated (`cloudflare-auth`, `api-token-mode`, `fetch-retry`, `index` scheduled, `oauth-handler` route/probe errors). **Zero stray `console.*` left in source.**

## Behavior changes (otherwise pure refactor)
1. **Refresh telemetry logs at `info`** (`console.log`) not `error` — it was mislabeling normal first-time/replay events as errors. Needle-based observability queries are level-agnostic, so unaffected.
2. **Failure-cache TTL: 3600s → 120s.** Permanent loop-prevention is now owned by **grant revocation** (#137), so the cache only needs to cover the KV eventual-consistency lag after revoke + the upstream **~1 min refresh coalescing grace window**. Production telemetry confirmed `cached_replay` had already drained to ~0/min (29.6→0.03), so the 1h TTL was only holding stale entries past when the grant was already dead.

## Verification
- **188 tests pass** (updated the refresh tests to call `refreshManager.run` directly — no compat shim — and the 3 `fetch-retry` log-format assertions to match the structured output).
- typecheck / format clean; only the pre-existing triple-slash lint warning in a test `.d.ts` remains.
