### PR TITLE
fix: stop tracking node_modules symlink; add type:http to README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Just connect to the MCP server URL - you'll be redirected to Cloudflare to autho
 {
   "mcpServers": {
     "cloudflare-api": {
+      "type": "http",
       "url": "https://mcp.cloudflare.com/mcp"
     }
   }
@@ -60,6 +61,7 @@ https://mcp.cloudflare.com/mcp?codemode=false
 {
   "mcpServers": {
     "cloudflare-api": {
+      "type": "http",
       "url": "https://mcp.cloudflare.com/mcp?codemode=false"
     }
   }

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/matt/Documents/Github/cloudflare-mcp/node_modules


### PR DESCRIPTION
Two small repo-hygiene fixes.

## 1. Stop tracking the `node_modules` symlink
PR #137 accidentally committed `node_modules` as a **git symlink** (mode `120000`) pointing to an absolute local path:
```
node_modules -> /Users/matt/Documents/Github/cloudflare-mcp/node_modules
```
Even though `node_modules/` is in `.gitignore`, the symlink **itself** was tracked, so it shipped to everyone — breaking fresh checkouts and leaking a local filesystem path.

Fix: `git rm --cached node_modules`. It's already gitignored, so it stays ignored locally and won't be re-added.

## 2. Add `"type": "http"` to README MCP config examples
Multiple Claude Code users reported they couldn't connect until they added `"type": "http"` to the `mcpServers` entry. Added it to both example blocks (default + `?codemode=false`) so the config works out of the box.

```json
{
  "mcpServers": {
    "cloudflare-api": {
      "type": "http",
      "url": "https://mcp.cloudflare.com/mcp"
    }
  }
}
```