### PR TITLE
Add Cloudflare docs search tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 | Raw OpenAPI spec in prompt                  | —     | ~2,000,000 | 977%                |
 | Native MCP (full schemas)                   | 2,594 | 1,170,523  | 585%                |
 | Native MCP (minimal — required params only) | 2,594 | 244,047    | 122%                |
-| Code mode                                   | 2     | 1,069      | 0.5%                |
+| Code mode                                   | 3     | ~1,100     | 0.5%                |
 
 ## Get Started
 
@@ -49,7 +49,7 @@ Create a [Cloudflare API token](https://dash.cloudflare.com/profile/api-tokens) 
 
 ### Disable Code Mode
 
-If your MCP client already uses code mode, or you're composing this server with another server that uses code mode, you can disable it with the `?codemode=false` query parameter. This registers an individual tool for each of the ~2,500 Cloudflare API endpoints instead of the 2 code mode tools.
+If your MCP client already uses code mode, or you're composing this server with another server that uses code mode, you can disable it with the `?codemode=false` query parameter. This registers an individual tool for each of the ~2,500 Cloudflare API endpoints instead of the code mode API tools. The `docs` tool remains available in both modes.
 
 ```
 https://mcp.cloudflare.com/mcp?codemode=false
@@ -84,10 +84,11 @@ This server solves the problem by using **code execution** in a [Code Mode](http
 
 ## Tools
 
-Agent writes code to search the spec and execute API calls.
+Agent writes code to search the spec and execute API calls. It can also search Cloudflare's developer documentation directly.
 
 | Tool      | Description                                                                   |
 | --------- | ----------------------------------------------------------------------------- |
+| `docs`    | Search Cloudflare developer documentation                                     |
 | `search`  | Write JavaScript to query `spec.paths` and find endpoints                     |
 | `execute` | Write JavaScript to call `cloudflare.request()` with the discovered endpoints |
 

--- a/src/docs-search.ts
+++ b/src/docs-search.ts
@@ -1,0 +1,208 @@
+import { z } from 'zod'
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+
+interface DocsSearchEnv {
+  AI?: Ai
+}
+
+const AiSearchResponseSchema = z.object({
+  object: z.string(),
+  search_query: z.string(),
+  data: z.array(
+    z.object({
+      file_id: z.string(),
+      filename: z.string(),
+      score: z.number(),
+      attributes: z
+        .object({
+          modified_date: z.number().optional(),
+          folder: z.string().optional()
+        })
+        .catchall(z.any()),
+      content: z.array(
+        z.object({
+          id: z.string(),
+          type: z.string(),
+          text: z.string()
+        })
+      )
+    })
+  ),
+  has_more: z.boolean(),
+  next_page: z.string().nullable()
+})
+
+type DocsSearchResult = {
+  similarity: number
+  id: string
+  url: string
+  title: string
+  text: string
+}
+
+type DocsSearchOutput = {
+  results: DocsSearchResult[]
+}
+
+const docsToolDescription = `Search the Cloudflare documentation.
+
+		This tool should be used to answer any question about Cloudflare products or features, including:
+		- Workers, Pages, R2, Images, Stream, D1, Durable Objects, KV, Workflows, Hyperdrive, Queues
+		- AI Search, Workers AI, Vectorize, AI Gateway, Browser Rendering
+		- Zero Trust, Access, Tunnel, Gateway, Browser Isolation, WARP, DDOS, Magic Transit, Magic WAN
+		- CDN, Cache, DNS, Zaraz, Argo, Rulesets, Terraform, Account and Billing
+
+		Results are returned as semantically similar chunks to the query.
+		`
+
+export function registerDocsTool(server: McpServer, env: DocsSearchEnv) {
+  server.registerTool(
+    'docs',
+    {
+      description: docsToolDescription,
+      inputSchema: {
+        query: z.string().describe('Cloudflare documentation search query')
+      },
+      outputSchema: {
+        results: z.array(
+          z.object({
+            similarity: z.number().describe('Similarity score from AI Search'),
+            id: z.string().describe('Source file ID'),
+            url: z.string().describe('Developer documentation URL'),
+            title: z.string().describe('Documentation page title'),
+            text: z.string().describe('Matching documentation chunk text')
+          })
+        )
+      },
+      annotations: {
+        readOnlyHint: true
+      }
+    },
+    async ({ query }) => {
+      if (!env.AI) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: 'Error: Cloudflare docs search is not configured in this environment.'
+            }
+          ],
+          isError: true
+        }
+      }
+
+      const structuredContent: DocsSearchOutput = {
+        results: await queryCloudflareDocs(env.AI, query)
+      }
+      return {
+        content: [{ type: 'text' as const, text: formatDocsResults(structuredContent.results) }],
+        structuredContent
+      }
+    }
+  )
+}
+
+export async function queryCloudflareDocs(ai: Ai, query: string): Promise<DocsSearchResult[]> {
+  const rawResponse = await doWithRetries(() =>
+    ai.autorag('docs-mcp-rag').search({
+      query
+    })
+  )
+
+  const response = AiSearchResponseSchema.parse(rawResponse)
+
+  return response.data.map((item) => ({
+    similarity: item.score,
+    id: item.file_id,
+    url: sourceToUrl(item.filename),
+    title: extractTitle(item.filename),
+    text: item.content.map((content) => content.text).join('\n')
+  }))
+}
+
+export function formatDocsResults(results: DocsSearchResult[]): string {
+  return results
+    .map(
+      (result) => `<result>
+<url>${result.url}</url>
+<title>${result.title}</title>
+<text>
+${result.text}
+</text>
+</result>`
+    )
+    .join('\n')
+}
+
+export function sourceToUrl(filename: string): string {
+  if (filename.startsWith('https://') || filename.startsWith('http://')) {
+    return filename
+  }
+
+  return (
+    'https://developers.cloudflare.com/' +
+    filename.replace(/index\.mdx?$/, '').replace(/\.mdx?$/, '')
+  )
+}
+
+export function extractTitle(filename: string): string {
+  const urlPath =
+    filename.startsWith('https://') || filename.startsWith('http://')
+      ? new URL(filename).pathname
+      : filename
+  const parts = urlPath
+    .replace(/\/$/, '')
+    .replace(/\.mdx?$/, '')
+    .split('/')
+  const lastPart = parts[parts.length - 1]
+
+  if (lastPart === 'index') {
+    return titleCase(parts[parts.length - 2] || 'Documentation')
+  }
+
+  return titleCase(lastPart || 'Documentation')
+}
+
+async function doWithRetries<T>(action: () => Promise<T>): Promise<T> {
+  const maxRetries = 5
+  const initialRetryMs = 100
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return await action()
+    } catch (error) {
+      console.error(`AI Search attempt ${attempt + 1} failed:`, error)
+
+      if (!isRetryableError(error) || attempt === maxRetries) {
+        throw error
+      }
+
+      await scheduler.wait(initialRetryMs * Math.pow(2, attempt))
+    }
+  }
+
+  throw new Error('An unknown error occurred')
+}
+
+function isRetryableError(error: unknown): boolean {
+  if (error && typeof error === 'object' && 'status' in error) {
+    const status = (error as { status: number }).status
+    return status >= 500 || status === 429
+  }
+
+  if (error instanceof Error) {
+    const message = error.message.toLowerCase()
+    return (
+      message.includes('timeout') ||
+      message.includes('network') ||
+      message.includes('connection') ||
+      message.includes('fetch')
+    )
+  }
+
+  return true
+}
+
+function titleCase(value: string): string {
+  return value.replace(/[-_]/g, ' ').replace(/\b\w/g, (letter) => letter.toUpperCase())
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,6 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { z } from 'zod'
+import { registerDocsTool } from './docs-search'
 import { createCodeExecutor, createSearchExecutor } from './executor'
 import { truncateResponse } from './truncate'
 import { fetchWithRetry } from './utils/fetch-retry'
@@ -402,6 +403,8 @@ export async function createServer(
     { name: 'cloudflare-api', version: '0.1.0' },
     instructions ? { instructions } : undefined
   )
+
+  registerDocsTool(server, env)
 
   if (!codemode) {
     await registerNonCodemodeTools(server, env, apiToken, accountId, props)

--- a/src/tests/docs-search.test.ts
+++ b/src/tests/docs-search.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi } from 'vitest'
+import { extractTitle, formatDocsResults, queryCloudflareDocs, sourceToUrl } from '../docs-search'
+
+describe('docs search', () => {
+  function makeAi(response: unknown): { ai: Ai; search: ReturnType<typeof vi.fn> } {
+    const search = vi.fn().mockResolvedValue(response)
+    return {
+      ai: {
+        autorag: vi.fn(() => ({ search }))
+      } as any,
+      search
+    }
+  }
+
+  const aiSearchResponse = {
+    object: 'vector_store.search_results.page',
+    search_query: 'workers kv binding example',
+    data: [
+      {
+        file_id: 'file-1',
+        filename: 'workers/runtime-apis/kv/index.md',
+        score: 0.93,
+        attributes: {},
+        content: [
+          { id: 'chunk-1', type: 'text', text: 'Create a KV namespace.' },
+          { id: 'chunk-2', type: 'text', text: 'Bind it to your Worker.' }
+        ]
+      }
+    ],
+    has_more: false,
+    next_page: null
+  }
+
+  it('queries the docs AI Search AutoRAG and maps results', async () => {
+    const { ai, search } = makeAi(aiSearchResponse)
+
+    const results = await queryCloudflareDocs(ai, 'workers kv binding example')
+
+    expect(ai.autorag).toHaveBeenCalledWith('docs-mcp-rag')
+    expect(search).toHaveBeenCalledWith({
+      query: 'workers kv binding example'
+    })
+    expect(results).toEqual([
+      {
+        similarity: 0.93,
+        id: 'file-1',
+        url: 'https://developers.cloudflare.com/workers/runtime-apis/kv/',
+        title: 'Kv',
+        text: 'Create a KV namespace.\nBind it to your Worker.'
+      }
+    ])
+  })
+
+  it('formats unstructured content as documentation result blocks', () => {
+    expect(
+      formatDocsResults([
+        {
+          similarity: 0.93,
+          id: 'file-1',
+          url: 'https://developers.cloudflare.com/workers/runtime-apis/kv/',
+          title: 'KV',
+          text: 'Create a KV namespace.'
+        }
+      ])
+    ).toBe(`<result>
+<url>https://developers.cloudflare.com/workers/runtime-apis/kv/</url>
+<title>KV</title>
+<text>
+Create a KV namespace.
+</text>
+</result>`)
+  })
+
+  it('turns docs filenames into developer docs URLs', () => {
+    expect(sourceToUrl('workers/configuration/index.md')).toBe(
+      'https://developers.cloudflare.com/workers/configuration/'
+    )
+    expect(sourceToUrl('workers/configuration/compatibility-dates.mdx')).toBe(
+      'https://developers.cloudflare.com/workers/configuration/compatibility-dates'
+    )
+  })
+
+  it('does not double-prefix full documentation URLs', () => {
+    expect(sourceToUrl('https://developers.cloudflare.com/r2/api/workers/')).toBe(
+      'https://developers.cloudflare.com/r2/api/workers/'
+    )
+  })
+
+  it('extracts titles from filenames and URLs', () => {
+    expect(extractTitle('workers/configuration/index.md')).toBe('Configuration')
+    expect(extractTitle('workers/configuration/compatibility-dates.mdx')).toBe(
+      'Compatibility Dates'
+    )
+    expect(extractTitle('https://developers.cloudflare.com/r2/api/workers/')).toBe('Workers')
+  })
+})

--- a/src/tests/non-codemode.test.ts
+++ b/src/tests/non-codemode.test.ts
@@ -511,6 +511,7 @@ describe('createServer with codemode=false', () => {
 
     const tools = (server as any)._registeredTools
     const toolNames = Object.keys(tools)
+    expect(toolNames).toContain('docs')
     expect(toolNames).toContain('get_accounts_workers_scripts')
     expect(toolNames).toContain('post_accounts_workers_scripts')
     expect(toolNames).toContain('get_zones_dns_records')
@@ -518,6 +519,24 @@ describe('createServer with codemode=false', () => {
     // Should NOT have codemode tools
     expect(toolNames).not.toContain('search')
     expect(toolNames).not.toContain('execute')
+  })
+
+  it('registers docs with the Cloudflare docs server description and output schema', async () => {
+    const env = makeMockEnv({})
+    const ctx = {
+      exports: { GlobalOutbound: vi.fn(() => ({ fetch: vi.fn() })) },
+      waitUntil: vi.fn()
+    } as any
+    const server = await createServer(env, ctx, 'test-token', 'test-account', undefined, true)
+
+    const docsTool = (server as any)._registeredTools['docs']
+    expect(docsTool.description).toContain(
+      'This tool should be used to answer any question about Cloudflare products or features'
+    )
+    expect(docsTool.description).toContain(
+      'Results are returned as semantically similar chunks to the query.'
+    )
+    expect(docsTool.outputSchema).toBeDefined()
   })
 
   it('registers codemode tools when codemode=true (default)', async () => {
@@ -536,6 +555,7 @@ describe('createServer with codemode=false', () => {
 
     const tools = (server as any)._registeredTools
     const toolNames = Object.keys(tools)
+    expect(toolNames).toContain('docs')
     expect(toolNames).toContain('search')
     expect(toolNames).toContain('execute')
     expect(toolNames).not.toContain('get_accounts_workers_scripts')

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -9,6 +9,7 @@ declare namespace Cloudflare {
 		OAUTH_KV: KVNamespace;
 		SPEC_BUCKET: R2Bucket;
 		LOADER: WorkerLoader;
+		AI: Ai;
 		CLOUDFLARE_API_BASE: string;
 		CLOUDFLARE_OAUTH_DOMAIN: string;
 		OPENAPI_SPEC_URL: "https://raw.githubusercontent.com/cloudflare/api-schemas/main/openapi.json";
@@ -22,6 +23,7 @@ declare namespace Cloudflare {
 		OAUTH_KV: KVNamespace;
 		SPEC_BUCKET: R2Bucket;
 		LOADER: WorkerLoader;
+		AI: Ai;
 		CLOUDFLARE_API_BASE: string;
 		CLOUDFLARE_OAUTH_DOMAIN: string;
 		OPENAPI_SPEC_URL: "https://raw.githubusercontent.com/cloudflare/api-schemas/main/openapi.json";
@@ -39,6 +41,7 @@ declare namespace Cloudflare {
 		OAUTH_KV: KVNamespace;
 		SPEC_BUCKET: R2Bucket;
 		LOADER: WorkerLoader;
+		AI?: Ai;
 		CLOUDFLARE_API_BASE: string;
 		CLOUDFLARE_OAUTH_DOMAIN: string;
 		OPENAPI_SPEC_URL: "https://raw.githubusercontent.com/cloudflare/api-schemas/main/openapi.json";

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -52,6 +52,9 @@
 	"env": {
 		"staging": {
 			"name": "cloudflare-api-mcp-staging",
+			"ai": {
+				"binding": "AI"
+			},
 			"routes": [
 				{
 					"pattern": "staging.mcp.cloudflare.com",
@@ -93,6 +96,9 @@
 		},
 		"production": {
 			"name": "cloudflare-api-mcp",
+			"ai": {
+				"binding": "AI"
+			},
 			"routes": [
 				{
 					"pattern": "mcp.cloudflare.com",


### PR DESCRIPTION
## Summary

- add a new `docs` MCP tool for searching Cloudflare Developer Documentation
- back the tool with the same AI Search AutoRAG index used by `docs.mcp.cloudflare.com` (`docs-mcp-rag`)
- use the same tool description as the current `mcp-server-cloudflare` docs AI Search tool
- return XML-style docs result blocks in normal text content, while exposing typed results via `outputSchema` / `structuredContent`
- register `docs` in both code mode and `?codemode=false`
- add the AI binding to staging and production Worker environments
- document the new third code-mode tool

## Notes

The current docs MCP server at `docs.mcp.cloudflare.com` reports `serverInfo.name = docs-ai-search` and `version = 0.4.8`; this mirrors that AI Search implementation rather than the older Vectorize path.

`/mcp` remains OAuth/API-token protected so clients still receive the normal auth challenge and login flow.

## Tests

- `npm run check`
  - passes with existing lint warning for `src/tests/cloudflare-test.d.ts` triple-slash reference
- staging unauthenticated `/mcp` smoke test returns expected OAuth `401` challenge