### PR TITLE
Add api_request metrics event (GlobalOutbound fan-out tracking)

### DIFF
--- a/src/executor.ts
+++ b/src/executor.ts
@@ -9,13 +9,18 @@ interface SearchExecutorEntrypoint {
 export function createCodeExecutor(env: Env, ctx: ExecutionContext) {
   const apiBase = env.CLOUDFLARE_API_BASE
 
-  return async (code: string, accountId: string, apiToken: string): Promise<unknown> => {
+  return async (
+    code: string,
+    accountId: string,
+    apiToken: string,
+    userId?: string
+  ): Promise<unknown> => {
     const workerId = `cloudflare-api-${crypto.randomUUID()}`
 
     const worker = env.LOADER.get(workerId, () => ({
       compatibilityDate: '2026-01-12',
       globalOutbound: ctx.exports.GlobalOutbound({
-        props: { apiToken, fetchWithRetryCaller: 'codemode_execute_tool_call' }
+        props: { apiToken, fetchWithRetryCaller: 'codemode_execute_tool_call', userId }
       }),
       mainModule: 'worker.js',
       modules: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { createAuthHandlers, handleTokenExchangeCallback } from './auth/oauth-ha
 import { isDirectApiToken, handleApiTokenRequest } from './auth/api-token-mode'
 import { processSpec, extractProducts } from './spec-processor'
 import { fetchWithRetry } from './utils/fetch-retry'
+import { ApiRequest, MetricsTracker, SERVER_INFO, normalizeApiPath } from './metrics'
 import type { AuthProps } from './auth/types'
 
 /**
@@ -14,7 +15,7 @@ import type { AuthProps } from './auth/types'
  * to only make requests to the configured Cloudflare API base URL.
  * The API token is injected via props so it never enters the user code isolate.
  */
-type GlobalOutboundProps = { apiToken: string; fetchWithRetryCaller: string }
+type GlobalOutboundProps = { apiToken: string; fetchWithRetryCaller: string; userId?: string }
 
 export class GlobalOutbound extends WorkerEntrypoint<Env, GlobalOutboundProps> {
   async fetch(request: Request): Promise<Response> {
@@ -30,9 +31,25 @@ export class GlobalOutbound extends WorkerEntrypoint<Env, GlobalOutboundProps> {
         ['Authorization', `Bearer ${this.ctx.props.apiToken}`]
       ])
     })
-    return fetchWithRetry(authedRequest, undefined, {
+    const response = await fetchWithRetry(authedRequest, undefined, {
       caller: this.ctx.props.fetchWithRetryCaller
     })
+
+    // Record one api_request datapoint per forwarded Cloudflare API call. This
+    // is the choke point every cloudflare.request() from the execute isolate
+    // passes through, so it captures the fan-out a single tool_call can't.
+    // logEvent swallows its own errors; metrics must never affect the proxy.
+    const metrics = new MetricsTracker(this.env.MCP_METRICS, SERVER_INFO)
+    metrics.logEvent(
+      new ApiRequest({
+        userId: this.ctx.props.userId,
+        method: request.method,
+        path: normalizeApiPath(request.url),
+        status: response.status
+      })
+    )
+
+    return response
   }
 }
 

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -7,12 +7,13 @@
  * the other servers and are picked up by existing dashboards/queries.
  *
  * Positional layout (must not change — the dataset columns are positional):
- *   index1  = event type (`tool_call` | `auth_user`)
+ *   index1  = event type (`tool_call` | `auth_user` | `api_request`)
  *   blob1   = MCP server name      (reserved, injected by the tracker)
  *   blob2   = MCP server version   (reserved, injected by the tracker)
  *   blob3   = userId
- *   blob4   = toolName (tool_call) | errorMessage (auth_user)
- *   double1 = errorCode (tool_call)
+ *   blob4   = toolName (tool_call) | errorMessage (auth_user) | HTTP method (api_request)
+ *   blob5   = normalized request path (api_request)
+ *   double1 = errorCode (tool_call) | HTTP response status (api_request)
  *
  * Note: this server is stateless (a fresh McpServer per request) so it does not
  * emit `session_start` events the way the Durable-Object-backed Cloudflare MCP
@@ -25,9 +26,47 @@
 
 export type ClientInfo = { name: string; version: string }
 
+/** Canonical server identity stamped onto every datapoint (blob1/blob2). */
+export const SERVER_INFO: ClientInfo = { name: 'cloudflare-api', version: '0.1.0' }
+
 export enum MetricsEventIndexId {
   AUTH_USER = 'auth_user',
-  TOOL_CALL = 'tool_call'
+  TOOL_CALL = 'tool_call',
+  API_REQUEST = 'api_request'
+}
+
+/**
+ * Normalize a Cloudflare API URL into a low-cardinality path template suitable
+ * for grouping in Analytics Engine. Strips the `/client/v4` version prefix and
+ * the query string, then replaces identifier-like segments (32-char hex account
+ * /zone/resource ids, UUIDs, and pure-numeric ids) with `{id}`.
+ *
+ * Caveat: user-named resources (worker script names, KV titles, DNS names) are
+ * NOT collapsed — only clearly identifier-shaped segments are. That keeps the
+ * common high-cardinality drivers (account/zone ids) bounded while preserving
+ * the endpoint shape; AE sampling absorbs the remaining tail.
+ */
+export function normalizeApiPath(rawUrl: string): string {
+  let path: string
+  try {
+    path = new URL(rawUrl).pathname
+  } catch {
+    path = rawUrl.split('?')[0]
+  }
+
+  // Strip the API version prefix, e.g. `/client/v4`.
+  path = path.replace(/^\/client\/v\d+/, '')
+
+  const HEX32 = /^[0-9a-f]{32}$/i
+  const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+  const NUMERIC = /^\d+$/
+
+  const normalized = path
+    .split('/')
+    .filter(Boolean)
+    .map((seg) => (HEX32.test(seg) || UUID.test(seg) || NUMERIC.test(seg) ? '{id}' : seg))
+
+  return '/' + normalized.join('/')
 }
 
 type Range1To20 =
@@ -153,6 +192,33 @@ export class ToolCall extends MetricsEvent {
       }),
       doubles: this.mapDoubles({
         double1: this.toolCall.errorCode
+      })
+    }
+  }
+}
+
+export class ApiRequest extends MetricsEvent {
+  constructor(
+    private apiRequest: {
+      userId?: string
+      method: string
+      path: string
+      status: number
+    }
+  ) {
+    super()
+  }
+
+  toDataPoint(): AnalyticsEngineDataPoint {
+    return {
+      indexes: [MetricsEventIndexId.API_REQUEST],
+      blobs: this.mapBlobs({
+        blob3: this.apiRequest.userId,
+        blob4: this.apiRequest.method,
+        blob5: this.apiRequest.path
+      }),
+      doubles: this.mapDoubles({
+        double1: this.apiRequest.status
       })
     }
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,10 +4,8 @@ import { registerDocsTool } from './docs-search'
 import { createCodeExecutor, createSearchExecutor } from './executor'
 import { truncateResponse } from './truncate'
 import { fetchWithRetry } from './utils/fetch-retry'
-import { MetricsTracker, ToolCall } from './metrics'
+import { MetricsTracker, SERVER_INFO, ToolCall } from './metrics'
 import type { AuthProps } from './auth/types'
-
-const SERVER_INFO = { name: 'cloudflare-api', version: '0.1.0' }
 
 /**
  * Resolve the userId to attribute metrics to. Only user tokens carry a user
@@ -474,6 +472,9 @@ export async function createServer(
   // Track tool_call metrics for every tool registered below.
   attachMetrics(server, env, props)
 
+  // Attributed to api_request datapoints emitted from the GlobalOutbound proxy.
+  const userId = userIdFromProps(props)
+
   registerDocsTool(server, env)
 
   if (!codemode) {
@@ -570,7 +571,7 @@ async () => {
       },
       async ({ code }) => {
         try {
-          const result = await executeCode(code, accountId, apiToken)
+          const result = await executeCode(code, accountId, apiToken, userId)
           return { content: [{ type: 'text', text: truncateResponse(result) }] }
         } catch (error) {
           return {
@@ -629,7 +630,7 @@ async () => {
             }
           }
 
-          const result = await executeCode(code, effectiveAccountId, apiToken)
+          const result = await executeCode(code, effectiveAccountId, apiToken, userId)
           return { content: [{ type: 'text', text: truncateResponse(result) }] }
         } catch (error) {
           return {

--- a/src/tests/metrics.test.ts
+++ b/src/tests/metrics.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it, vi } from 'vitest'
-import { AuthUser, MetricsEventIndexId, MetricsError, MetricsTracker, ToolCall } from '../metrics'
+import {
+  ApiRequest,
+  AuthUser,
+  MetricsEventIndexId,
+  MetricsError,
+  MetricsTracker,
+  normalizeApiPath,
+  ToolCall
+} from '../metrics'
 
 const SERVER_INFO = { name: 'cloudflare-api', version: '0.1.0' }
 
@@ -22,6 +30,73 @@ describe('ToolCall', () => {
     const dp = event.toDataPoint()
 
     expect(dp.doubles).toEqual([-32602])
+  })
+})
+
+describe('ApiRequest', () => {
+  it('maps method, normalized path and status to the correct slots', () => {
+    const event = new ApiRequest({
+      userId: 'user-1',
+      method: 'GET',
+      path: '/accounts/{id}/workers/scripts',
+      status: 200
+    })
+    event.serverInfo = SERVER_INFO
+    const dp = event.toDataPoint()
+
+    expect(dp.indexes).toEqual([MetricsEventIndexId.API_REQUEST])
+    // blob3=userId, blob4=method, blob5=path
+    expect(dp.blobs).toEqual([
+      'cloudflare-api',
+      '0.1.0',
+      'user-1',
+      'GET',
+      '/accounts/{id}/workers/scripts'
+    ])
+    // double1 = HTTP status
+    expect(dp.doubles).toEqual([200])
+  })
+})
+
+describe('normalizeApiPath', () => {
+  it('strips the /client/v4 prefix and the query string', () => {
+    const acct = '6702657b6aa048cf3081ff3ff3c9c52f'
+    expect(normalizeApiPath(`https://api.cloudflare.com/client/v4/accounts/${acct}?page=2`)).toBe(
+      '/accounts/{id}'
+    )
+  })
+
+  it('replaces 32-char hex account/zone ids with {id}', () => {
+    const acct = '6702657b6aa048cf3081ff3ff3c9c52f'
+    expect(
+      normalizeApiPath(`https://api.cloudflare.com/client/v4/accounts/${acct}/workers/scripts`)
+    ).toBe('/accounts/{id}/workers/scripts')
+  })
+
+  it('replaces UUIDs and numeric ids', () => {
+    expect(
+      normalizeApiPath(
+        'https://api.cloudflare.com/client/v4/accounts/123456/d1/database/3f2504e0-4f89-41d3-9a0c-0305e82c3301/query'
+      )
+    ).toBe('/accounts/{id}/d1/database/{id}/query')
+  })
+
+  it('preserves user-named resource segments (not id-shaped)', () => {
+    expect(
+      normalizeApiPath(
+        'https://api.cloudflare.com/client/v4/accounts/6702657b6aa048cf3081ff3ff3c9c52f/workers/scripts/my-worker'
+      )
+    ).toBe('/accounts/{id}/workers/scripts/my-worker')
+  })
+
+  it('handles the graphql endpoint', () => {
+    expect(normalizeApiPath('https://api.cloudflare.com/client/v4/graphql')).toBe('/graphql')
+  })
+
+  it('falls back gracefully on a non-URL string', () => {
+    expect(normalizeApiPath('/client/v4/accounts/6702657b6aa048cf3081ff3ff3c9c52f?x=1')).toBe(
+      '/accounts/{id}'
+    )
   })
 })
 


### PR DESCRIPTION
## What

Adds a third Analytics Engine metrics event, **`api_request`**, recorded from the `GlobalOutbound` proxy — the choke point every `cloudflare.request()` from the `execute` isolate passes through. Builds on the merged metrics work (#153).

## Why

`tool_call` tells us how many times `execute`/`search` ran, but **not** what happened underneath. A single `execute` can fan out to many Cloudflare API calls. `api_request` captures that layer, giving the full funnel:

```
tool_call   → how many execute/search invocations
api_request → which endpoints, success/error/429 rates, fan-out per call
```

## Schema (same shared `mcp-metrics-*` dataset)

Reuses the positional slot conventions so cross-server queries stay compatible:

| slot | `api_request` value |
|---|---|
| `index1` | `api_request` |
| `blob1`/`blob2` | server name/version (reserved) |
| `blob3` | userId |
| `blob4` | HTTP method |
| `blob5` | normalized request path |
| `double1` | HTTP response status |

## Cardinality control

`normalizeApiPath()` keeps `blob5` bounded:
- strips the `/client/v4` prefix and the query string
- replaces identifier-shaped segments — 32-char hex (account/zone/resource ids), UUIDs, and pure-numeric ids — with `{id}`

```
/client/v4/accounts/6702.../d1/database/3f25...-.../query
        → /accounts/{id}/d1/database/{id}/query
```

User-named resources (worker script names, KV titles, DNS names) are **intentionally not** collapsed — only clearly id-shaped segments are. That bounds the dominant cardinality drivers while preserving endpoint shape; AE sampling (`_sample_interval`) absorbs the tail.

## Implementation notes

- **Safety**: `logEvent` swallows its own errors and the tracker is a no-op without the binding — metrics can never affect the proxy or a tool call. The disallowed-host `403` early-return is deliberately **not** recorded (it's not a forwarded API call).
- **Attribution**: `userId` is threaded `server.ts → createCodeExecutor → GlobalOutbound` props.
- **Final status only**: `fetchWithRetry` retries internally, so a 429-then-success logs once as `200`. Acceptable for v1.

## Scope (deliberate)

Covers codemode **`execute`** (the default path). Non-codemode tools call `fetchWithRetry` directly rather than through `GlobalOutbound`, so they aren't captured here. The search isolate uses `globalOutbound: null` and correctly emits nothing.

## Example query

```sql
SELECT blob4 AS method, blob5 AS path, double1 AS status, count() AS n
FROM 'mcp-metrics-production'
WHERE blob1 = 'cloudflare-api' AND index1 = 'api_request'
  AND timestamp > NOW() - INTERVAL '1' DAY
GROUP BY method, path, status
ORDER BY n DESC
```

## Testing

`npm run check` fully green — format, lint, typecheck, and **213 tests** pass (7 new: `ApiRequest` mapping + `normalizeApiPath` cases incl. hex/UUID/numeric/user-named/graphql/fallback).
