### PR TITLE
fix: stop logging expected auth-probe client errors

### DIFF
--- a/src/auth/oauth-handler.ts
+++ b/src/auth/oauth-handler.ts
@@ -397,7 +397,16 @@ export async function getUserAndAccounts(
 
   // Check for upstream errors before parsing
   if (!userResp.ok && !accountsResp.ok) {
-    console.error(`Cloudflare API error: user=${userResp.status}, accounts=${accountsResp.status}`)
+    // Only log genuinely actionable failures. Client errors (400/401/403) are
+    // expected when callers present malformed, expired, or unauthorized tokens,
+    // and 429s are already logged in fetchWithRetry — logging them here just
+    // inflates the error rate with noise.
+    const isServerError = [userResp.status, accountsResp.status].some((status) => status >= 500)
+    if (isServerError) {
+      console.error(
+        `Cloudflare API error: user=${userResp.status}, accounts=${accountsResp.status}`
+      )
+    }
     throwCombinedCloudflareApiError(userResp, accountsResp)
   }
 


### PR DESCRIPTION
## What

The auth-guard identity probe (`getUserAndAccounts`) logs **every** combined upstream failure at `console.error`:

```
Cloudflare API error: user=400, accounts=400
```

But 400/401/403 responses are **expected** whenever a caller presents a malformed, expired, or unauthorized token — they're normal client errors, not server problems.

## Why

Querying Workers Observability for `cloudflare-api-mcp` over the last 7 days, these two messages alone accounted for ~65k of ~127k errored events:

| Count | Message |
|------:|---------|
| 46,500 | `Cloudflare API error: user=400, accounts=400` |
| 18,710 | `Cloudflare API error: user=403, accounts=403` |

They were a flat, steady baseline across the whole retention window (no regression onset) — just non-actionable noise inflating the worker's error rate by ~half.

## Change

Only log when at least one probe returns a **5xx** (genuinely actionable). 429s are already logged in `fetchWithRetry`, so they aren't re-logged here. The thrown `OAuthError` responses are unchanged — behaviour for callers is identical, only the logging is quieter.

## Testing

- `npm run check` (format, lint, typecheck) ✅
- `npm run test` — 221 passed ✅