### PR TITLE
fix: clarify multi-account discovery guidance

### DIFF
--- a/src/auth/account-access.ts
+++ b/src/auth/account-access.ts
@@ -3,6 +3,16 @@ import { LEGACY_ACCOUNTS_PAGE_SIZE, type AuthProps } from './types'
 type UserToken = Extract<AuthProps, { type: 'user_token' }>
 type Account = UserToken['accounts'][number]
 
+/** Concise Code-Mode guidance for unresolved multi-account execution errors. */
+export const ACCOUNT_DISCOVERY_GUIDANCE = 'Call GET /accounts to discover available accounts.'
+
+/** Detailed Code-Mode guidance for tool descriptions. */
+export const ACCOUNT_DISCOVERY_DESCRIPTION = `${ACCOUNT_DISCOVERY_GUIDANCE} Paginate as needed, or filter by exact name with GET /accounts?name=<exact account name>.`
+
+/** Non-Code-Mode guidance using the generated endpoint tool name. */
+export const NON_CODEMODE_ACCOUNT_DISCOVERY_GUIDANCE =
+  'Call the get_accounts tool to discover available accounts.'
+
 /**
  * Account selection helpers — the single source of truth for how a session's
  * `props` map onto "which Cloudflare account does an API call target". Keep all

--- a/src/tools/execute.ts
+++ b/src/tools/execute.ts
@@ -6,6 +6,8 @@ import { truncateResponse } from '../truncate'
 import { fetchWithRetry } from '../utils/fetch-retry'
 import { formatError } from '../utils/errors'
 import {
+  ACCOUNT_DISCOVERY_DESCRIPTION,
+  ACCOUNT_DISCOVERY_GUIDANCE,
   accountTokenId,
   autoResolvedAccountId,
   inlineableAccounts,
@@ -69,10 +71,11 @@ async function runExecute(
   // don't bind a usable `accountId`. Account-independent calls (GET /accounts,
   // GET /user) never touch it, but any code that reads it fails fast with a
   // clear message instead of silently producing `/accounts//...` (a 404).
+  const unresolvedAccountMessage = `No account selected: this token has access to multiple accounts. ${ACCOUNT_DISCOVERY_GUIDANCE}`
   const accountIdPrelude = accountId
     ? `const accountId = ${JSON.stringify(accountId)};`
     : `Object.defineProperty(globalThis, "accountId", { configurable: true, get() {
-        throw new Error("No account selected: this token has access to multiple accounts. Call GET /accounts to find one, then pass account_id to the execute tool.");
+        throw new Error(${JSON.stringify(unresolvedAccountMessage)});
       } });`
 
   const worker = env.LOADER.get(workerId, () => ({
@@ -226,9 +229,7 @@ function cloudflareTypesForAccount(props?: AuthProps): string {
   if (isMultiAccountUser(props)) {
     return (
       CLOUDFLARE_TYPES +
-      `\n// This token has access to multiple Cloudflare accounts.\n` +
-      `// accountId is set from the account_id tool argument, or is empty when omitted.\n` +
-      `// To discover account IDs, omit account_id and call GET /accounts with pagination.\n`
+      `\n// accountId is set from the optional account_id tool argument. Reading it before selecting an account throws an error.\n`
     )
   }
 
@@ -241,11 +242,12 @@ function cloudflareTypesForAccount(props?: AuthProps): string {
  */
 function executeToolDescription(props?: AuthProps): string {
   const types = cloudflareTypesForAccount(props)
+  const accountSelection = accountSelectionDescription(props)
 
   return `Execute JavaScript code against the Cloudflare API. First use the 'search' tool to find the right endpoints, then write code using the cloudflare.request() function.
 
 Available in your code:
-${types}
+${types}${accountSelection}
 
 Your code must be an async arrow function that returns the result.
 
@@ -259,30 +261,29 @@ async () => {
 }`
 }
 
-/**
- * Describe the optional `account_id` argument for multi-account user-token
- * `execute` sessions.
- *
- * - Small, complete account lists are inlined so the model can pick directly.
- * - Otherwise (omitted large list or incomplete legacy list) we point the model
- *   at paginated `GET /accounts` for discovery.
- */
-function accountIdParamDescription(props?: AuthProps): string {
-  if (!isMultiAccountUser(props)) {
-    return 'Your Cloudflare account ID. Optional if you have only one account (will be auto-selected)'
-  }
+function accountSelectionDescription(props?: AuthProps): string {
+  if (!isMultiAccountUser(props)) return ''
 
   const accounts = inlineableAccounts(props)
   if (accounts) {
-    const list = accounts.map((a) => `${a.id} (${a.name})`).join(', ')
-    return `Your Cloudflare account ID. Required for account-scoped API calls. Available accounts: ${list}`
+    const list = accounts.map((account) => `- ${account.id} (${account.name})`).join('\n')
+    return `
+
+Available accounts:
+${list}`
   }
 
-  const countNote =
+  const access =
     props.accountCount !== undefined
-      ? ` This token has access to ${props.accountCount} accounts.`
-      : ''
-  return `Your Cloudflare account ID. Required for account-scoped API calls.${countNote} Omit this argument and page through GET /accounts to discover them, or filter by exact name with GET /accounts?name=<exact account name>.`
+      ? `This token has access to ${props.accountCount} Cloudflare accounts.`
+      : 'This token has access to multiple Cloudflare accounts.'
+  return `
+
+${access} ${ACCOUNT_DISCOVERY_DESCRIPTION}`
+}
+
+function accountIdParamDescription(): string {
+  return 'Cloudflare account ID to scope execution to a singular account. Optional for account-independent calls.'
 }
 
 /**
@@ -326,7 +327,7 @@ export function registerExecuteTool(server: McpServer, props: AuthProps): void {
       description,
       inputSchema: {
         code: z.string().describe('JavaScript async arrow function to execute'),
-        account_id: z.string().optional().describe(accountIdParamDescription(props))
+        account_id: z.string().optional().describe(accountIdParamDescription())
       }
     },
     async ({ code, account_id }) => {

--- a/src/tools/non-codemode.ts
+++ b/src/tools/non-codemode.ts
@@ -10,7 +10,11 @@ import {
 import { truncateResponse } from '../truncate'
 import { fetchWithRetry } from '../utils/fetch-retry'
 import { getNonCodemodeToolMap, getNonCodemodeTools } from '../isolate-cache'
-import { autoResolvedAccountId, isMultiAccountUser } from '../auth/account-access'
+import {
+  NON_CODEMODE_ACCOUNT_DISCOVERY_GUIDANCE,
+  autoResolvedAccountId,
+  isMultiAccountUser
+} from '../auth/account-access'
 import { recordToolCall } from '../metrics'
 import { DOCS_TOOL, runDocsTool } from './docs-search'
 import { zodInputSchemaFromJson, type NonCodemodeTool } from '../openapi'
@@ -121,7 +125,12 @@ async function callNonCodemodeTool(
 }
 
 function validationError(name: string, error: z.ZodError): CallToolResult {
-  return toolError(`Input validation error: Invalid arguments for tool ${name}: ${error.message}`)
+  const accountGuidance = error.issues.some((issue) => issue.path[0] === 'account_id')
+    ? ` ${NON_CODEMODE_ACCOUNT_DISCOVERY_GUIDANCE}`
+    : ''
+  return toolError(
+    `Input validation error: Invalid arguments for tool ${name}: ${error.message}${accountGuidance}`
+  )
 }
 
 function toolError(message: string): CallToolResult {
@@ -149,7 +158,7 @@ function toolForAccountAccess(
   } else if (isMultiAccountUser(props)) {
     properties['account_id'] = {
       type: 'string',
-      description: 'Cloudflare account ID. Required for multi-account tokens.'
+      description: `Cloudflare account ID. Required for multi-account tokens. ${NON_CODEMODE_ACCOUNT_DISCOVERY_GUIDANCE}`
     }
   }
 

--- a/tests/executor.test.ts
+++ b/tests/executor.test.ts
@@ -153,7 +153,8 @@ describe('execute: no account resolved (multi-account user token)', () => {
     })
     const text = toolText(result)
     expect(text).toContain('No account selected')
-    expect(text).toContain('GET /accounts')
+    expect(text).toContain('Call GET /accounts to discover available accounts.')
+    expect(text).not.toContain('pass account_id to the execute tool')
     // Must not have silently produced an /accounts//... request.
     expect(text).not.toContain('/accounts//')
   })

--- a/tests/non-codemode.test.ts
+++ b/tests/non-codemode.test.ts
@@ -668,7 +668,7 @@ describe('createServer with codemode=false', () => {
     expect(toolNames).not.toContain('get_accounts_workers_scripts')
   })
 
-  it('includes a small account list only in the execute account_id parameter', async () => {
+  it('includes a small account list only in the execute tool description', async () => {
     const accounts = Array.from({ length: 30 }, (_, index) => ({
       id: `acct-${index + 1}`,
       name: `Account ${index + 1}`
@@ -686,10 +686,13 @@ describe('createServer with codemode=false', () => {
     const accountIdDescription = execute.inputSchema.shape.account_id.description
 
     expect((server as any).server._instructions).toBeUndefined()
-    expect(execute.description).not.toContain('acct-1')
-    expect(execute.description).not.toContain('Available accounts')
-    expect(accountIdDescription).toContain('acct-1 (Account 1)')
-    expect(accountIdDescription).toContain('acct-30 (Account 30)')
+    expect(execute.description).toContain('Available accounts')
+    expect(execute.description).toContain('acct-1 (Account 1)')
+    expect(execute.description).toContain('acct-30 (Account 30)')
+    expect(accountIdDescription).not.toContain('acct-1')
+    expect(accountIdDescription).toBe(
+      'Cloudflare account ID to scope execution to a singular account. Optional for account-independent calls.'
+    )
   })
 
   it('treats a legacy grant (no version) with exactly 20 accounts as incomplete', async () => {
@@ -710,8 +713,10 @@ describe('createServer with codemode=false', () => {
     const accountIdDescription = execute.inputSchema.shape.account_id.description
 
     expect(accountIdDescription).not.toContain('legacy-acct-1')
-    expect(accountIdDescription).toContain('GET /accounts')
+    expect(accountIdDescription).not.toContain('GET /accounts')
+    expect(execute.description).not.toContain('legacy-acct-1')
     expect(execute.description).toContain('multiple Cloudflare accounts')
+    expect(execute.description).toContain('GET /accounts')
   })
 
   it('inlines exactly 20 accounts when the grant is versioned (complete)', async () => {
@@ -732,8 +737,9 @@ describe('createServer with codemode=false', () => {
     const execute = (server as any)._registeredTools['execute']
     const accountIdDescription = execute.inputSchema.shape.account_id.description
 
-    expect(accountIdDescription).toContain('fresh-acct-1 (Fresh Account 1)')
-    expect(accountIdDescription).toContain('fresh-acct-20 (Fresh Account 20)')
+    expect(execute.description).toContain('fresh-acct-1 (Fresh Account 1)')
+    expect(execute.description).toContain('fresh-acct-20 (Fresh Account 20)')
+    expect(accountIdDescription).not.toContain('fresh-acct-1')
   })
 
   it('reports only the count when the account list was omitted at the identity layer', async () => {
@@ -750,10 +756,12 @@ describe('createServer with codemode=false', () => {
     const execute = (server as any)._registeredTools['execute']
     const accountIdDescription = execute.inputSchema.shape.account_id.description
 
-    expect(accountIdDescription).toContain('137 accounts')
-    expect(accountIdDescription).toContain('GET /accounts')
-    expect(accountIdDescription).toContain('GET /accounts?name=')
-    expect(execute.description).toContain('multiple Cloudflare accounts')
+    expect(accountIdDescription).not.toContain('137 accounts')
+    expect(accountIdDescription).not.toContain('GET /accounts')
+    expect(execute.description).toContain('137 Cloudflare accounts')
+    expect(execute.description).not.toContain('multiple Cloudflare accounts')
+    expect(execute.description).toContain('GET /accounts')
+    expect(execute.description).toContain('GET /accounts?name=')
   })
 
   // NOTE: "execute without account_id runs account-independent discovery calls"
@@ -1208,10 +1216,37 @@ describe('createServer with codemode=false', () => {
     expect(listedTool?.inputSchema.required).toContain('account_id')
     expect(listedTool?.inputSchema.properties?.account_id).toEqual({
       type: 'string',
-      description: 'Cloudflare account ID. Required for multi-account tokens.'
+      description:
+        'Cloudflare account ID. Required for multi-account tokens. Call the get_accounts tool to discover available accounts.'
     })
     expect(JSON.stringify(listedTool)).not.toContain('Account One')
     expect(JSON.stringify(listedTool)).not.toContain('acct-1')
+  })
+
+  it('adds account discovery guidance when multi-account account_id is missing', async () => {
+    const specPaths = {
+      '/accounts/{account_id}/workers/scripts': {
+        get: { summary: 'List Workers' } as OperationInfo
+      }
+    }
+    const props: AuthProps = {
+      type: 'user_token',
+      accessToken: 'test-token',
+      user: { id: 'u1', email: 'test@example.com' },
+      accounts: [
+        { id: 'acct-1', name: 'Account One' },
+        { id: 'acct-2', name: 'Account Two' }
+      ]
+    }
+
+    await seedSpec(specPaths)
+    const server = await createServer(props, false)
+    const result = await callTool(server, 'get_accounts_workers_scripts', {})
+
+    expect(result.isError).toBe(true)
+    expect(result.content[0].text).toContain(
+      'Call the get_accounts tool to discover available accounts.'
+    )
   })
 
   it('drops account_id from the schema for account-token sessions', async () => {


### PR DESCRIPTION
## Summary

Follow-up to #158 that makes multi-account discovery guidance accurate for both Code Mode and Non-Code-Mode.

### Code Mode

- Move small, complete account lists out of the `execute.account_id` field description and into the main `execute` tool description, so dynamic account metadata appears in one place.
- Keep `account_id` stable and generic:

  > Cloudflare account ID to scope execution to a singular account. Optional for account-independent calls.

- For small complete lists, show an `Available accounts` section in the execute description.
- For omitted/incomplete lists, show the exact count when available plus discovery guidance, pagination, and exact-name filtering.
- Standardize the unresolved `accountId` error:

  > No account selected: this token has access to multiple accounts. Call GET /accounts to discover available accounts.

- Remove the misleading instruction to pass `account_id` to `execute`: Code Mode can discover account IDs and use them directly in API paths within the same invocation.

### Non-Code-Mode

Non-Code-Mode cannot call raw `GET /accounts`; it must invoke the generated endpoint tool. Its schema and validation errors now say:

> Call the get_accounts tool to discover available accounts.

`get_accounts` itself has no `account_id` parameter and works for unresolved multi-account sessions.

### Shared guidance

Centralize the mode-specific discovery strings in `src/auth/account-access.ts` so descriptions and errors cannot drift independently.

## Validation

- `npm run check`
- **255 tests across 16 files**
- Added/updated coverage for:
  - account-list placement in the execute description;
  - stable identity-free `account_id` field metadata;
  - count-only and incomplete-list descriptions;
  - concise unresolved-account errors; and
  - mode-correct Non-Code-Mode schema and validation guidance.

Also verified against production with a multi-account user token:

- `get_accounts` succeeds without `account_id`;
- discovered IDs can be used directly in Code-Mode API paths;
- account-scoped Non-Code-Mode tools require a discovered ID; and
- no account IDs are embedded in the generated Non-Code-Mode tool list.
