### PR TITLE
build: upgrade workers OAuth provider to 0.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "cloudflare-mcp",
       "version": "0.1.0",
       "dependencies": {
-        "@cloudflare/workers-oauth-provider": "^0.6.0",
+        "@cloudflare/workers-oauth-provider": "^0.8.0",
         "@modelcontextprotocol/sdk": "^1.26.0",
         "hono": "^4.12.25",
         "zod": "^4.3.5"
@@ -166,9 +166,9 @@
       }
     },
     "node_modules/@cloudflare/workers-oauth-provider": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-oauth-provider/-/workers-oauth-provider-0.6.0.tgz",
-      "integrity": "sha512-KOkTWEjwVjfYGU78eyapKziuPuzKw9gIg4LpxbGmxWhNl4bAdiJzWXeV3nepFr+vmkEiTMEGk99Llj5j0tH2cw==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-oauth-provider/-/workers-oauth-provider-0.8.0.tgz",
+      "integrity": "sha512-Vb2mjT9R+rLS9FcHgd5+ab4u7SP0ZB7x7t9M94JNMdN5e2ogRf3NOUCPW6NhBCTPwKu36VrfrYPPNGjOek4VYQ==",
       "license": "MIT"
     },
     "node_modules/@cspotcode/source-map-support": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "seed:prod": "tsx scripts/seed-r2.ts production"
   },
   "dependencies": {
-    "@cloudflare/workers-oauth-provider": "^0.6.0",
+    "@cloudflare/workers-oauth-provider": "^0.8.0",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "hono": "^4.12.25",
     "zod": "^4.3.5"

--- a/src/auth/oauth-handler.ts
+++ b/src/auth/oauth-handler.ts
@@ -102,6 +102,8 @@ export interface RefreshGuardContext {
   userId?: string
   /** Downstream OAuth client id (from the token-exchange callback options). */
   clientId?: string
+  /** Exact downstream grant being refreshed. */
+  grantId?: string
   /**
    * Lazily builds OAuth helpers (via `getOAuthApi`). Only invoked on a terminal
    * `invalid_grant` so we don't construct the provider on every refresh.
@@ -132,35 +134,6 @@ function logRefreshTelemetry(event: {
   grantsRevoked?: number
 }): void {
   console.error(`[refresh-telemetry] ${JSON.stringify({ ...event, at: Date.now() })}`)
-}
-
-/**
- * Kill every grant for this user+client. `completeAuthorization` revokes prior
- * grants for the same user+client by default, so in practice there is at most
- * one, but we loop defensively (and paginate). `revokeGrant` deletes all access
- * tokens for the grant and the grant record itself, which invalidates the
- * downstream refresh token too.
- */
-async function revokeGrantsForClient(
-  helpers: OAuthHelpers,
-  userId: string,
-  clientId: string
-): Promise<number> {
-  let revoked = 0
-  let cursor: string | undefined
-  do {
-    const page = await helpers.listUserGrants(userId, cursor ? { cursor } : undefined)
-    for (const grant of page.items) {
-      // Match on client AND user. listUserGrants is expected to scope by userId,
-      // but double-check defensively so a provider bug can never let us revoke a
-      // different user's grant for the same clientId.
-      if (grant.clientId !== clientId || grant.userId !== userId) continue
-      await helpers.revokeGrant(grant.id, userId)
-      revoked++
-    }
-    cursor = page.cursor
-  } while (cursor)
-  return revoked
 }
 
 async function getCachedRefreshFailure(
@@ -305,15 +278,12 @@ export async function guardRefreshTokenExchange(
           if (
             error.code === 'invalid_grant' &&
             context.userId &&
-            context.clientId &&
+            context.grantId &&
             context.getHelpers
           ) {
             try {
-              grantsRevoked = await revokeGrantsForClient(
-                context.getHelpers(),
-                context.userId,
-                context.clientId
-              )
+              await context.getHelpers().revokeGrant(context.grantId, context.userId)
+              grantsRevoked = 1
             } catch (revokeError) {
               console.error(
                 'Refresh guard: failed to revoke grant after invalid_grant',
@@ -548,6 +518,7 @@ export async function handleTokenExchangeCallback(
     {
       userId: options.userId,
       clientId: options.clientId,
+      grantId: options.grantId,
       getHelpers
     }
   )

--- a/tests/auth/oauth-handler.test.ts
+++ b/tests/auth/oauth-handler.test.ts
@@ -1,4 +1,5 @@
 import {
+  GrantType,
   OAuthError as ProviderOAuthError,
   type OAuthHelpers
 } from '@cloudflare/workers-oauth-provider'
@@ -47,20 +48,10 @@ function deferred<T>(): {
   return { promise, resolve, reject }
 }
 
-interface MockGrant {
-  id: string
-  clientId: string
-  userId: string
-}
-
-/**
- * Minimal OAuthHelpers mock backing the revoke-on-invalid_grant path. Only
- * listUserGrants/revokeGrant are exercised; cast to the full type since the
- * guard never touches the other members.
- */
-function mockOAuthHelpers(grants: MockGrant[]) {
+/** Minimal OAuthHelpers mock backing the revoke-on-invalid_grant path. */
+function mockOAuthHelpers() {
   return {
-    listUserGrants: vi.fn(async () => ({ items: grants as never[], cursor: undefined })),
+    listUserGrants: vi.fn(),
     revokeGrant: vi.fn(async () => undefined)
   } as unknown as OAuthHelpers & {
     listUserGrants: ReturnType<typeof vi.fn>
@@ -510,29 +501,26 @@ describe('guardRefreshTokenExchange', () => {
     expect(refreshFn).toHaveBeenCalledTimes(1)
   })
 
-  it('revokes the grant for this user+client on upstream invalid_grant', async () => {
+  it('revokes the exact grant on upstream invalid_grant', async () => {
     const kv = env.OAUTH_KV
     const refreshFn = vi
       .fn()
       .mockRejectedValueOnce(new OAuthError('invalid_grant', 'refresh token reused', 400))
-    const helpers = mockOAuthHelpers([
-      { id: 'grant-keep', clientId: 'other-client', userId: 'user-1' },
-      { id: 'grant-kill', clientId: 'mcp-client', userId: 'user-1' }
-    ])
+    const helpers = mockOAuthHelpers()
     const getHelpers = vi.fn(() => helpers)
 
     await expectOAuthError(
       guardRefreshTokenExchange(kv, 'dead-token', refreshFn, {
         userId: 'user-1',
         clientId: 'mcp-client',
+        grantId: 'grant-kill',
         getHelpers
       }),
       'invalid_grant',
       400
     )
 
-    // Only the matching user+client grant is killed; other clients untouched.
-    expect(helpers.listUserGrants).toHaveBeenCalledWith('user-1', undefined)
+    expect(helpers.listUserGrants).not.toHaveBeenCalled()
     expect(helpers.revokeGrant).toHaveBeenCalledTimes(1)
     expect(helpers.revokeGrant).toHaveBeenCalledWith('grant-kill', 'user-1')
   })
@@ -544,7 +532,7 @@ describe('guardRefreshTokenExchange', () => {
       .mockRejectedValueOnce(
         new OAuthError('temporarily_unavailable', 'rate limited', 429, { 'Retry-After': '30' })
       )
-    const helpers = mockOAuthHelpers([{ id: 'grant-1', clientId: 'mcp-client', userId: 'user-1' }])
+    const helpers = mockOAuthHelpers()
     const getHelpers = vi.fn(() => helpers)
 
     await expectOAuthError(
@@ -566,7 +554,7 @@ describe('guardRefreshTokenExchange', () => {
     const refreshFn = vi
       .fn()
       .mockRejectedValueOnce(new OAuthError('invalid_client', 'bad client creds', 401))
-    const helpers = mockOAuthHelpers([{ id: 'grant-1', clientId: 'mcp-client', userId: 'user-1' }])
+    const helpers = mockOAuthHelpers()
     const getHelpers = vi.fn(() => helpers)
 
     await expectOAuthError(
@@ -588,89 +576,34 @@ describe('guardRefreshTokenExchange', () => {
     const refreshFn = vi
       .fn()
       .mockRejectedValueOnce(new OAuthError('invalid_grant', 'refresh token reused', 400))
-    const helpers = mockOAuthHelpers([
-      { id: 'grant-kill', clientId: 'mcp-client', userId: 'user-1' }
-    ])
+    const helpers = mockOAuthHelpers()
     vi.mocked(helpers.revokeGrant).mockRejectedValueOnce(new Error('KV unavailable'))
 
     await expectOAuthError(
       guardRefreshTokenExchange(kv, 'dead-token-revoke-fails', refreshFn, {
         userId: 'user-1',
         clientId: 'mcp-client',
+        grantId: 'grant-kill',
         getHelpers: () => helpers
       }),
       'invalid_grant',
       400
     )
-  })
-
-  it('paginates listUserGrants when revoking', async () => {
-    const kv = env.OAUTH_KV
-    const refreshFn = vi
-      .fn()
-      .mockRejectedValueOnce(new OAuthError('invalid_grant', 'refresh token reused', 400))
-    const helpers = mockOAuthHelpers([])
-    vi.mocked(helpers.listUserGrants)
-      .mockResolvedValueOnce({
-        items: [{ id: 'grant-a', clientId: 'mcp-client', userId: 'user-1' } as never],
-        cursor: 'next'
-      } as never)
-      .mockResolvedValueOnce({
-        items: [{ id: 'grant-b', clientId: 'mcp-client', userId: 'user-1' } as never],
-        cursor: undefined
-      } as never)
-
-    await expectOAuthError(
-      guardRefreshTokenExchange(kv, 'paginated-token', refreshFn, {
-        userId: 'user-1',
-        clientId: 'mcp-client',
-        getHelpers: () => helpers
-      }),
-      'invalid_grant',
-      400
-    )
-
-    expect(helpers.listUserGrants).toHaveBeenCalledTimes(2)
-    expect(helpers.revokeGrant).toHaveBeenCalledWith('grant-a', 'user-1')
-    expect(helpers.revokeGrant).toHaveBeenCalledWith('grant-b', 'user-1')
-  })
-
-  it('never revokes another user grant for the same client (defense-in-depth)', async () => {
-    const kv = env.OAUTH_KV
-    const refreshFn = vi
-      .fn()
-      .mockRejectedValueOnce(new OAuthError('invalid_grant', 'refresh token reused', 400))
-    // listUserGrants is supposed to scope by userId, but simulate a provider
-    // returning a same-client grant belonging to a DIFFERENT user. We must not
-    // revoke it — only the calling user's matching grant.
-    const helpers = mockOAuthHelpers([
-      { id: 'grant-mine', clientId: 'mcp-client', userId: 'user-1' },
-      { id: 'grant-other-user', clientId: 'mcp-client', userId: 'user-2' }
-    ])
-
-    await expectOAuthError(
-      guardRefreshTokenExchange(kv, 'cross-user-token', refreshFn, {
-        userId: 'user-1',
-        clientId: 'mcp-client',
-        getHelpers: () => helpers
-      }),
-      'invalid_grant',
-      400
-    )
-
-    expect(helpers.revokeGrant).toHaveBeenCalledTimes(1)
-    expect(helpers.revokeGrant).toHaveBeenCalledWith('grant-mine', 'user-1')
-    expect(helpers.revokeGrant).not.toHaveBeenCalledWith('grant-other-user', 'user-1')
   })
 })
 
 describe('handleTokenExchangeCallback', () => {
   const OAUTH_TOKEN_URL = 'https://dash.cloudflare.com/oauth2/token'
 
-  const refreshCallback = (refreshToken = 'old-refresh-token') =>
+  const refreshCallback = (refreshToken = 'old-refresh-token', getHelpers?: () => OAuthHelpers) =>
     handleTokenExchangeCallback(
       {
-        grantType: 'refresh_token',
+        grantType: GrantType.REFRESH_TOKEN,
+        clientId: 'mcp-client',
+        userId: 'user-1',
+        grantId: 'grant-exact',
+        scope: [],
+        requestedScope: [],
         props: {
           type: 'user_token',
           accessToken: 'old-access-token',
@@ -678,9 +611,10 @@ describe('handleTokenExchangeCallback', () => {
           accounts: [{ id: 'account-1', name: 'Account 1' }],
           refreshToken
         }
-      } as never,
+      },
       'client-id',
-      'client-secret'
+      'client-secret',
+      getHelpers
     )
 
   it('refreshes upstream tokens and returns updated auth props', async () => {
@@ -715,17 +649,20 @@ describe('handleTokenExchangeCallback', () => {
     expect(form?.get('refresh_token')).toBe('old-refresh-token')
   })
 
-  it('throws the local OAuthError that extends the provider OAuthError', async () => {
+  it('revokes the callback grant when upstream returns invalid_grant', async () => {
     // Upstream 400 -> real refreshAuthToken maps it to invalid_grant.
     server.use(
       http.post(OAUTH_TOKEN_URL, () => HttpResponse.text('invalid grant', { status: 400 }))
     )
+    const helpers = mockOAuthHelpers()
 
-    await expect(refreshCallback()).rejects.toMatchObject({
+    await expect(refreshCallback('old-refresh-token', () => helpers)).rejects.toMatchObject({
       name: 'OAuthError',
       code: 'invalid_grant',
       statusCode: 400
     })
+    expect(helpers.listUserGrants).not.toHaveBeenCalled()
+    expect(helpers.revokeGrant).toHaveBeenCalledWith('grant-exact', 'user-1')
   })
 
   it('preserves Retry-After on a local in-flight collision (429)', async () => {


### PR DESCRIPTION
## Summary

Upgrade `@cloudflare/workers-oauth-provider` from `^0.6.0` to `^0.8.0` and adopt its new exact `grantId` callback context.

When Cloudflare rejects a stored upstream refresh token with `invalid_grant`, the server now revokes only the downstream grant currently being refreshed:

```ts
await helpers.revokeGrant(options.grantId, options.userId)
```

This replaces the previous paginated sweep over every grant for the same `(userId, clientId)` pair. It is simpler, avoids unnecessary KV reads, and cannot revoke a different concurrent grant for the same client.

## Relevant upstream changes

### Security and correctness hardening

- Validate an authorization code and requesting client before acting on a grant during code exchange.
- Verify client ownership during token revocation and honor `token_type_hint`.
- Tighten token-endpoint client authentication parsing for RFC 6749 compliance.
- Add `Cache-Control: no-store` and `Pragma: no-cache` to token, credential, registration, and OAuth error responses.
- Bound KV pagination while revoking existing grants during authorization.

### API additions used here

- `TokenExchangeCallbackOptions.grantId` identifies the authoritative grant record being refreshed and is stable for that grant's lifetime.
- The refresh failure guard threads this ID into `OAuthHelpers.revokeGrant(grantId, userId)`.

Other new optional features—Enterprise-Managed Authorization and the dynamic-client-registration policy callback—remain disabled.

Upstream releases:

- https://github.com/cloudflare/workers-oauth-provider/releases/tag/v0.7.0
- https://github.com/cloudflare/workers-oauth-provider/releases/tag/v0.8.0

## Compatibility review

- `OAuthProvider`, `getOAuthApi`, `AuthRequest`, `OAuthError`, and `OAuthHelpers` exports used by this repository remain available.
- `parseAuthRequest()` and `completeAuthorization()` retain their contracts.
- Existing KV grants and tokens retain compatible storage handling; no binding or deployment changes are required.
- The package has no npm security advisory. The value of this upgrade is upstream protocol and authorization-logic hardening.

## Test changes

- Assert upstream `invalid_grant` revokes the exact callback `grantId`.
- Assert `listUserGrants()` is never called.
- Exercise the behavior both at the refresh guard boundary and through the real `handleTokenExchangeCallback` path.
- Preserve coverage that transient errors and server credential errors do not revoke grants.
- Preserve coverage that revoke failures do not mask the original `invalid_grant`.
- Remove obsolete pagination and cross-user sweep tests along with the deleted sweep implementation.

## Validation

- `npm run check`: **261 tests across 16 files**
- `npm audit --omit=dev` reports no vulnerability against `@cloudflare/workers-oauth-provider`.
