### PR TITLE
docs: add Claude Code connection guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,29 @@ Create a [Cloudflare API token](https://dash.cloudflare.com/profile/api-tokens) 
 
 > **Note:** API tokens with **Client IP Address Filtering** enabled are not currently supported.
 
+### Claude Code
+
+Add the Cloudflare MCP server to Claude Code using the CLI:
+
+```bash
+claude mcp add cloudflare-api --transport http https://mcp.cloudflare.com/mcp
+```
+
+Or manually create/edit `.mcp.json` in your project root:
+
+```json
+{
+  "mcpServers": {
+    "cloudflare-api": {
+      "type": "http",
+      "url": "https://mcp.cloudflare.com/mcp"
+    }
+  }
+}
+```
+
+After adding the server, restart Claude Code and you'll be prompted to authorize via Cloudflare OAuth on first use.
+
 ### Add to Agent
 
 | Setting      | Value                                                                       |


### PR DESCRIPTION
## Summary

Adds a dedicated **Claude Code** section to the README showing how to connect the Cloudflare MCP server, addressing #39.

## Changes

- Added "Claude Code" subsection under "Option 2: API Token"
- Documents both methods:
  - CLI: `claude mcp add cloudflare-api --transport http https://mcp.cloudflare.com/mcp`
  - Manual `.mcp.json` file with `"type": "http"` (the key detail that was missing per the issue)
- Notes OAuth authorization flow on first use

Closes #39