### PR TITLE
Add account analytics OAuth scope

### DIFF
--- a/src/auth/scopes.ts
+++ b/src/auth/scopes.ts
@@ -8,6 +8,7 @@ export const ALL_SCOPES = {
   offline_access: 'Grants refresh tokens for long-lived access',
   'user:read': 'See your user info such as name, email address, and account memberships',
   'account:read': 'See your account info such as account details, analytics, and memberships',
+  'account_analytics:read': 'View account-level analytics including RUM and Web Analytics data',
 
   // Access
   'access:read': 'View Access policies',
@@ -128,10 +129,10 @@ export const ALL_SCOPES = {
 /**
  * Maximum number of scopes that can be requested in a single OAuth authorization.
  * Cloudflare's OAuth server returns "Something went wrong!" when too many scopes
- * are requested. This limit is enforced server-side. Verified on staging that 78
- * scopes are accepted (full yolo template including notification:read/write).
+ * are requested. This limit is enforced server-side and should match the largest
+ * built-in template.
  */
-export const MAX_SCOPES = 78
+export const MAX_SCOPES = 79
 
 export type ScopeName = keyof typeof ALL_SCOPES
 

--- a/tests/auth/scopes.test.ts
+++ b/tests/auth/scopes.test.ts
@@ -15,6 +15,7 @@ const REGISTERED_SCOPES = [
   'offline_access',
   'user:read',
   'account:read',
+  'account_analytics:read',
   'access:read',
   'access:write',
   'workers:read',


### PR DESCRIPTION
## why
- cloudflare/mcp#162
- The Cloudflare GraphQL Analytics API requires `account_analytics:read` for RUM and Web Analytics data, but the MCP server did not include that OAuth scope

## how
### Scope list
- Add `account_analytics:read` to `ALL_SCOPES`
- Include it in the read-only template through the existing read-scope collection logic
- Raise `MAX_SCOPES` to 79 so the full-access template can include the new scope