### PR TITLE
feat: serve modern MCP with a stateless SDK v2 handler

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,9 +108,9 @@ The core innovation: instead of 2,500 MCP tools (~244K tokens), two tools handle
 ### MCP HTTP serving
 
 - `src/mcp-handler.ts` uses `createMcpHandler(factory)` directly from `@modelcontextprotocol/server`; this repository does not depend on the Agents SDK.
-- The module-scoped handler serves MCP `2026-07-28` and keeps the upstream default stateless 2025 compatibility path.
-- The factory creates a fresh `McpServer` for every request. No MCP session ID, protocol transport state, replay store, or Durable Object is used.
-- OAuth and direct API-token requests are verified before dispatch. Validated `AuthProps` reach the per-request factory through Worker `AsyncLocalStorage` and are captured by the new server.
+- Each authenticated request creates an upstream handler whose factory closes over validated `AuthProps`, matching the repository's pre-migration explicit data flow.
+- The handler serves MCP `2026-07-28` and keeps the upstream default stateless 2025 compatibility path. Its factory creates a fresh `McpServer` for every request.
+- No MCP session ID, protocol transport state, replay store, Durable Object, or Node async-context bridge is used.
 - Deployment-static Host and browser Origin allowlists cover localhost, staging, and production. Do not derive either trust list from the incoming request URL or headers.
 
 ### Worker Loader API

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,12 +18,13 @@ When modifying MCP or OAuth functionality, **always check the latest published M
 ```
 cloudflare-mcp/
 ├── src/
-│   ├── index.ts                   # Worker entry point & OAuth/Hono routing
+│   ├── index.ts                   # Worker entry point & OAuth routing
+│   ├── mcp-handler.ts             # Stateless MCP HTTP handler & deployment guards
 │   ├── server.ts                  # MCP server setup & tool registration
 │   ├── executor.ts                # Code executor (Worker Loader API)
 │   ├── spec-processor.ts          # OpenAPI spec fetching & $ref resolution
 │   ├── truncate.ts                # Response truncation (~6K token limit)
-│   ├── metrics.ts                 # Analytics Engine metrics (session_start/tool_call)
+│   ├── metrics.ts                 # Analytics Engine metrics (auth_user/tool_call)
 │   ├── auth/
 │   │   ├── types.ts               # Auth props schemas (Zod discriminated union)
 │   │   ├── api-token-mode.ts      # Direct Cloudflare API token support
@@ -104,6 +105,14 @@ The core innovation: instead of 2,500 MCP tools (~244K tokens), two tools handle
 1. **`search` tool** — Agents write JavaScript to query the pre-resolved OpenAPI spec (all `$ref`s inlined). Runs in an isolated worker with no network access.
 2. **`execute` tool** — Agents write JavaScript using `cloudflare.request()` to call discovered endpoints. Runs in an isolated worker with outbound restricted to Cloudflare API URLs only.
 
+### MCP HTTP serving
+
+- `src/mcp-handler.ts` uses `createMcpHandler(factory)` directly from `@modelcontextprotocol/server`; this repository does not depend on the Agents SDK.
+- The module-scoped handler serves MCP `2026-07-28` and keeps the upstream default stateless 2025 compatibility path.
+- The factory creates a fresh `McpServer` for every request. No MCP session ID, protocol transport state, replay store, or Durable Object is used.
+- OAuth and direct API-token requests are verified before dispatch. Validated `AuthProps` reach the per-request factory through Worker `AsyncLocalStorage` and are captured by the new server.
+- Deployment-static Host and browser Origin allowlists cover localhost, staging, and production. Do not derive either trust list from the incoming request URL or headers.
+
 ### Worker Loader API
 
 Code execution uses Cloudflare's Worker Loader API to dynamically create isolated worker instances. The API token is passed via props (never enters user code isolate). A `globalOutbound` service restricts network access.
@@ -136,7 +145,7 @@ Tool usage is tracked via the `MCP_METRICS` Analytics Engine binding into the sh
 
 - `src/metrics.ts` mirrors the upstream `@repo/mcp-observability` schema. The blob/double layout is **positional and must not change**: `index1` = event type, `blob1`/`blob2` = server name/version (reserved), `blob3` = userId, `blob4` = toolName/errorMessage, `double1` = errorCode.
 - `attachMetrics()` in `src/server.ts` wraps Code-Mode `registerTool` calls; the lazy non-Code-Mode dispatcher records the same `tool_call` events directly. `auth_user` events are emitted from the OAuth handler.
-- **No `session_start`**: unlike the Durable-Object-backed servers, this server is stateless (a fresh `McpServer` per request), so `oninitialized` fires on a different request than `initialize` and can never see client info. Client identity comes from the HTTP `User-Agent` header (visible in zone HTTP analytics) instead.
+- **No `session_start`**: MCP `2026-07-28` has no protocol sessions or `initialize` handshake. The 2025 compatibility path also creates a fresh server for each request and retains no initialization state. Client identity remains visible at the HTTP layer through `User-Agent` (including zone HTTP analytics).
 - The tracker is tolerant of a missing binding (no-op in tests/local dev) and swallows write errors so metrics can never break a tool call.
 - Query via the Analytics Engine SQL API: `SELECT ... FROM 'mcp-metrics-production' WHERE blob1='cloudflare-api' AND index1='tool_call'`.
 
@@ -147,6 +156,7 @@ Tool usage is tracked via the `MCP_METRICS` Analytics Engine binding into the sh
 - Search tool runs with no network access
 - OAuth uses PKCE (RFC 7636) for secure authorization
 - Cookie encryption for OAuth sessions (`MCP_COOKIE_ENCRYPTION_KEY`)
+- The `/mcp` route validates Host and present browser Origin headers against deployment-static allowlists before authentication
 
 ## Testing
 

--- a/MIGRATION_TRACKER.md
+++ b/MIGRATION_TRACKER.md
@@ -22,8 +22,8 @@ at `fe731a8`.
 | 8   | Protect the HTTP boundary             | Static localhost/staging/production Host and Origin allowlists run before authentication; modern CORS preflight headers are served explicitly                 | Done    |
 | 9   | Add wire regressions                  | Modern discovery/list, concurrent Code Mode surfaces, stateless 2025 fallback, GET/DELETE rejection, Host/Origin policy, preflight, and real OAuth token flow | Done    |
 | 10  | Validate locally                      | `npm run check`: 17 files / 289 tests; `npm ci`, dependency tree, and production audit clean                                                                  | Done    |
-| 11  | Bundle staging configuration          | Wrangler dry run: 1294.38 KiB raw / 242.98 KiB gzip                                                                                                           | Done    |
-| 12  | Deploy and smoke-test production      | Performed separately after the reviewed branch is pushed and the pull request is opened                                                                        | Pending |
+| 11  | Bundle production configuration       | Production upload: 1294.29 KiB raw / 242.92 KiB gzip; 120 ms startup                                                                                           | Done   |
+| 12  | Deploy and smoke-test production      | Runtime commit `ba95888`; version `bca4d618-2eab-429b-a62a-71623c98c55e`; authenticated modern and legacy smokes passed                                        | Done   |
 
 ### Serving design
 
@@ -69,9 +69,13 @@ npx wrangler deploy --dry-run --env staging
   Worker Loader execution remains covered separately.
 - `npm ci`, `npm ls --all`, and the production dependency audit are clean. The
   unmet entries shown by `npm ls` are platform/framework optional dependencies.
-- The staging dry-run bundle is **1294.38 KiB raw / 242.98 KiB gzip**.
-  Production deployment and smoke-test results are recorded separately after
-  the reviewed branch is pushed.
+- Production deployed from runtime commit `ba95888` as version
+  `bca4d618-2eab-429b-a62a-71623c98c55e`: **1294.29 KiB raw / 242.92 KiB
+  gzip**, with a **120 ms** startup.
+- Live authenticated smoke tests passed for modern discovery, list, Code Mode
+  call, non-Code-Mode call, and the stateless legacy fallback. Public metadata,
+  auth rejection, CORS preflight, hostile-Origin rejection, no-session headers,
+  and authenticated GET `405` behavior also passed.
 
 ## Historical beta.2 upgrade tally (`2.0.0-beta.1` → `2.0.0-beta.2`)
 

--- a/MIGRATION_TRACKER.md
+++ b/MIGRATION_TRACKER.md
@@ -1,22 +1,88 @@
 # MCP TypeScript SDK v2 Migration Tracker
 
 Tracks the migration from `@modelcontextprotocol/sdk` v1 to the split v2
-packages, plus follow-up upgrades while v2 is in beta. Both packages are pinned
-to the latest beta published on npm, `2.0.0-beta.2` (verified 2026-07-06).
+packages and the later move to the stateless MCP `2026-07-28` HTTP handler.
+`@modelcontextprotocol/server` and the test-only client are exact-pinned to the
+latest published beta, `2.0.0-beta.4` (verified 2026-07-20).
 
-Current upgrade branch: `chore/mcp-sdk-beta-2`, created from `origin/main` at
-`3d46b04`.
+Current upgrade branch: `feat/mcp-sdk-v2-stateless`, created from `origin/main`
+at `fe731a8`.
 
-## Beta upgrade tally (`2.0.0-beta.1` → `2.0.0-beta.2`)
+## Stateless beta.4 handler migration
 
-| # | Change | Repository impact | Status |
-| --- | --- | --- | --- |
-| 1 | Upgrade `@modelcontextprotocol/server` | Production dependency pinned to `2.0.0-beta.2` | Done |
-| 2 | Upgrade `@modelcontextprotocol/client` | Test-only dev dependency pinned to `2.0.0-beta.2` | Done |
-| 3 | Refresh npm lock data | Tarball URLs and integrity hashes now resolve beta.2 | Done |
-| 4 | Review beta.2 compatibility | No application source changes required | Done |
-| 5 | Run repository validation | Format, lint, typecheck, and all 265 tests pass | Done |
-| 6 | Deploy and smoke-test staging | Deployed; metadata/auth routes pass, Wrangler-token limitation documented | Done |
+| #   | Change                                | Repository impact                                                                                                                                             | Status  |
+| --- | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| 1   | Upgrade the split SDK packages        | Server and test client exact-pinned to `2.0.0-beta.4`; lockfile updated as one transaction                                                                    | Done    |
+| 2   | Adopt the upstream HTTP entry         | `src/mcp-handler.ts` uses `createMcpHandler(factory)` directly from `@modelcontextprotocol/server`                                                            | Done    |
+| 3   | Serve modern MCP                      | MCP `2026-07-28` requests use a fresh SDK v2 server factory                                                                                                   | Done    |
+| 4   | Retain published-client compatibility | The upstream default stateless 2025 fallback remains enabled; `legacy: 'reject'` is not set                                                                   | Done    |
+| 5   | Keep the protocol stateless           | No MCP session ID, transport storage, event replay state, Durable Object, SSE GET, or session DELETE path                                                     | Done    |
+| 6   | Preserve application and auth state   | OAuth grants, credentials, API-token identity cache, R2 spec artifacts, Analytics Engine, and Worker Loader infrastructure remain                             | Done    |
+| 7   | Preserve both auth modes              | Direct API tokens and provider-issued OAuth tokens both supply validated `AuthProps` to the request-local factory through Worker `AsyncLocalStorage`          | Done    |
+| 8   | Protect the HTTP boundary             | Static localhost/staging/production Host and Origin allowlists run before authentication; modern CORS preflight headers are served explicitly                 | Done    |
+| 9   | Add wire regressions                  | Modern discovery/list, concurrent Code Mode surfaces, stateless 2025 fallback, GET/DELETE rejection, Host/Origin policy, preflight, and real OAuth token flow | Done    |
+| 10  | Validate locally                      | `npm run check`: 17 files / 289 tests; `npm ci`, dependency tree, and production audit clean                                                                  | Done    |
+| 11  | Bundle staging configuration          | Wrangler dry run: 1294.38 KiB raw / 242.98 KiB gzip                                                                                                           | Done    |
+| 12  | Deploy and smoke-test production      | Performed separately after the reviewed branch is pushed and the pull request is opened                                                                        | Pending |
+
+### Serving design
+
+- A module-scoped upstream handler owns shared handler controls while its factory
+  returns a new `McpServer` for every HTTP request.
+- The repository has no dependency on the Agents SDK. The only MCP runtime
+  packages are the split TypeScript SDK packages.
+- The existing `?codemode=false` request input is read from the factory's
+  `requestInfo`, so concurrent requests can safely expose different tool
+  surfaces without sharing a connected server.
+- Authentication remains outside the MCP SDK. Both verified auth paths enter a
+  request-local `AsyncLocalStorage<AuthProps>` scope before calling the handler;
+  the factory validates and captures those props in the fresh server.
+- Handler options are intentionally omitted, preserving the upstream defaults:
+  `legacy: 'stateless'` and `responseMode: 'auto'`.
+- Ordinary modern responses remain JSON. The upstream stateless 2025 fallback
+  returns SSE for claimless legacy requests; this is compatible with Streamable
+  HTTP clients, which must accept both JSON and SSE, and no session ID is issued.
+- Browser Host/Origin trust is deployment-static. It must never be derived from
+  the incoming request URL, Host header, or Origin header.
+
+### Beta.4 validation
+
+```sh
+npm ci
+npm run check
+npm ls --all
+npm audit --omit=dev
+npx wrangler deploy --dry-run --env staging
+```
+
+- `format:check`, lint, typecheck, and all **289 tests in 17 files** pass.
+- Modern wire tests cover `server/discover`, `tools/list`, `resultType`, absent
+  `Mcp-Session-Id`, and concurrent Code Mode/non-Code-Mode factories.
+- Legacy wire tests prove claimless 2025 `tools/list` still works statelessly and
+  authenticated bodyless GET/DELETE requests return `405` without factory
+  construction, while unauthenticated requests remain protected with `401`.
+- Deployment tests cover accepted production Host/Origin, rejected foreign and
+  self-consistent attacker Host/Origin pairs, and authenticated modern CORS
+  preflight headers.
+- The real OAuth provider integration completes registration, authorization,
+  callback, code exchange, and a modern authenticated `tools/list`; direct-token
+  Worker Loader execution remains covered separately.
+- `npm ci`, `npm ls --all`, and the production dependency audit are clean. The
+  unmet entries shown by `npm ls` are platform/framework optional dependencies.
+- The staging dry-run bundle is **1294.38 KiB raw / 242.98 KiB gzip**.
+  Production deployment and smoke-test results are recorded separately after
+  the reviewed branch is pushed.
+
+## Historical beta.2 upgrade tally (`2.0.0-beta.1` → `2.0.0-beta.2`)
+
+| #   | Change                                 | Repository impact                                                         | Status |
+| --- | -------------------------------------- | ------------------------------------------------------------------------- | ------ |
+| 1   | Upgrade `@modelcontextprotocol/server` | Production dependency pinned to `2.0.0-beta.2`                            | Done   |
+| 2   | Upgrade `@modelcontextprotocol/client` | Test-only dev dependency pinned to `2.0.0-beta.2`                         | Done   |
+| 3   | Refresh npm lock data                  | Tarball URLs and integrity hashes now resolve beta.2                      | Done   |
+| 4   | Review beta.2 compatibility            | No application source changes required                                    | Done   |
+| 5   | Run repository validation              | Format, lint, typecheck, and all 265 tests pass                           | Done   |
+| 6   | Deploy and smoke-test staging          | Deployed; metadata/auth routes pass, Wrangler-token limitation documented | Done   |
 
 Beta.2 adds ESM/CommonJS dual-package exports to both packages. The server also
 fixes the HTTP mapping for a post-dispatch `MissingRequiredClientCapabilityError`
@@ -24,13 +90,13 @@ so an uncommitted response uses the specification-required `400 Bad Request`.
 This repository consumes the ESM/workerd exports and does not directly handle
 that SDK error, so neither release change requires source adaptation.
 
-## Package changes
+## Historical package split
 
-| Package | Before | After |
-| --- | --- | --- |
-| `@modelcontextprotocol/sdk` | `^1.26.0` (dep) | removed |
-| `@modelcontextprotocol/server` | — | `2.0.0-beta.2` (dep) |
-| `@modelcontextprotocol/client` | — | `2.0.0-beta.2` (devDep, tests only) |
+| Package                        | Before          | After                               |
+| ------------------------------ | --------------- | ----------------------------------- |
+| `@modelcontextprotocol/sdk`    | `^1.26.0` (dep) | removed                             |
+| `@modelcontextprotocol/server` | —               | `2.0.0-beta.2` (dep)                |
+| `@modelcontextprotocol/client` | —               | `2.0.0-beta.2` (devDep, tests only) |
 
 v2 is a package split: the server APIs move to `@modelcontextprotocol/server`
 (root export — there is no `/server/*` or `/types.js` subpath anymore) and the
@@ -42,14 +108,14 @@ Schema validator inline (`validators/cf-worker`) and selects it automatically on
 the `workerd`/`browser` export conditions via the package's `_shims` entry, so
 wrangler's bundle picks it up with no extra wiring.
 
-## Code changes
+## Historical v1-to-v2 code changes
 
 ### Imports (`@modelcontextprotocol/sdk/...` → `@modelcontextprotocol/server`)
 
-- `src/index.ts` — `WebStandardStreamableHTTPServerTransport`. This transport
-  still exists in v2 (root export, same options: `sessionIdGenerator`,
-  `enableJsonResponse`, `retryInterval`; same `handleRequest(request)` /
-  `close()`), so this is a one-line import repoint with no behavior change.
+- At this stage, `src/index.ts` continued using
+  `WebStandardStreamableHTTPServerTransport`. The beta.4 migration above later
+  replaced that raw transport wiring with the upstream `createMcpHandler`
+  factory entry.
 - `src/server.ts`, `src/metrics.ts` — `McpServer` (value / type).
 - `src/tools/{search,execute,docs-search}.ts` — `McpServer` type; `Tool` type.
 
@@ -103,7 +169,7 @@ precomputed artifacts:
 
 ## Validation
 
-### Current beta.2 upgrade
+### Historical beta.2 upgrade
 
 ```sh
 npm run check   # format:check, lint, typecheck, test

--- a/MIGRATION_TRACKER.md
+++ b/MIGRATION_TRACKER.md
@@ -18,7 +18,7 @@ at `fe731a8`.
 | 4   | Retain published-client compatibility | The upstream default stateless 2025 fallback remains enabled; `legacy: 'reject'` is not set                                                                   | Done    |
 | 5   | Keep the protocol stateless           | No MCP session ID, transport storage, event replay state, Durable Object, SSE GET, or session DELETE path                                                     | Done    |
 | 6   | Preserve application and auth state   | OAuth grants, credentials, API-token identity cache, R2 spec artifacts, Analytics Engine, and Worker Loader infrastructure remain                             | Done    |
-| 7   | Preserve both auth modes              | Direct API tokens and provider-issued OAuth tokens both supply validated `AuthProps` to the request-local factory through Worker `AsyncLocalStorage`          | Done    |
+| 7   | Preserve both auth modes              | Direct API tokens and provider-issued OAuth tokens both pass validated `AuthProps` explicitly into a request-local handler factory                           | Done    |
 | 8   | Protect the HTTP boundary             | Static localhost/staging/production Host and Origin allowlists run before authentication; modern CORS preflight headers are served explicitly                 | Done    |
 | 9   | Add wire regressions                  | Modern discovery/list, concurrent Code Mode surfaces, stateless 2025 fallback, GET/DELETE rejection, Host/Origin policy, preflight, and real OAuth token flow | Done    |
 | 10  | Validate locally                      | `npm run check`: 17 files / 289 tests; `npm ci`, dependency tree, and production audit clean                                                                  | Done    |
@@ -27,16 +27,16 @@ at `fe731a8`.
 
 ### Serving design
 
-- A module-scoped upstream handler owns shared handler controls while its factory
-  returns a new `McpServer` for every HTTP request.
+- Each authenticated HTTP request creates an upstream handler whose factory
+  closes over the request's validated `AuthProps`, preserving the explicit data
+  flow used before this migration.
 - The repository has no dependency on the Agents SDK. The only MCP runtime
   packages are the split TypeScript SDK packages.
 - The existing `?codemode=false` request input is read from the factory's
   `requestInfo`, so concurrent requests can safely expose different tool
   surfaces without sharing a connected server.
-- Authentication remains outside the MCP SDK. Both verified auth paths enter a
-  request-local `AsyncLocalStorage<AuthProps>` scope before calling the handler;
-  the factory validates and captures those props in the fresh server.
+- No Node ambient types, async-context bridge, or implicit global auth state is
+  required.
 - Handler options are intentionally omitted, preserving the upstream defaults:
   `legacy: 'stateless'` and `responseMode: 'auto'`.
 - Ordinary modern responses remain JSON. The upstream stateless 2025 fallback

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,13 @@
       "version": "0.1.0",
       "dependencies": {
         "@cloudflare/workers-oauth-provider": "^0.8.0",
-        "@modelcontextprotocol/server": "2.0.0-beta.2",
+        "@modelcontextprotocol/server": "2.0.0-beta.4",
         "hono": "^4.12.25",
         "zod": "^4.3.5"
       },
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.16.18",
-        "@modelcontextprotocol/client": "2.0.0-beta.2",
+        "@modelcontextprotocol/client": "2.0.0-beta.4",
         "@types/node": "^25.0.6",
         "msw": "^2.14.6",
         "oxfmt": "^0.31.0",
@@ -1315,12 +1315,13 @@
       }
     },
     "node_modules/@modelcontextprotocol/client": {
-      "version": "2.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/client/-/client-2.0.0-beta.2.tgz",
-      "integrity": "sha512-IKEJQmvM2g7HLSOofLXECjQyeryB1YWgjazHcYygyH3ERSe7b8cFS3WHlupMxees5URNXcqBLVlbDRgodaBQ9A==",
+      "version": "2.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/client/-/client-2.0.0-beta.4.tgz",
+      "integrity": "sha512-VNHA/UXDk7mCpVl+jOg5B4WMRRD2OEl+it360Lhi6HiCbrIB2f6pZ0cqSDKXQVUtZvqnhdQHzZAM9h8EKWhq/A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@modelcontextprotocol/core": "2.0.0-beta.4",
         "cross-spawn": "^7.0.5",
         "eventsource": "^3.0.2",
         "eventsource-parser": "^3.0.0",
@@ -1332,12 +1333,25 @@
         "node": ">=20"
       }
     },
-    "node_modules/@modelcontextprotocol/server": {
-      "version": "2.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server/-/server-2.0.0-beta.2.tgz",
-      "integrity": "sha512-XK+sgFntT5ZzeqtTGpT9uti+Sqmq7YJZdx/N76eLJv9UA9vKvP04Qh9Hc45LCeIHGfTKRwDG6eh4C1Hs4omyIg==",
+    "node_modules/@modelcontextprotocol/core": {
+      "version": "2.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/core/-/core-2.0.0-beta.4.tgz",
+      "integrity": "sha512-nsMXd4wQBKzmph6r+WOhum+mXjDYljTAqwY/XUg3hLtvNOQ8+JVqBSJOVCMJvx9lXhTpTOPrGZ3BuNiaNPjSvg==",
       "license": "MIT",
       "dependencies": {
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@modelcontextprotocol/server": {
+      "version": "2.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server/-/server-2.0.0-beta.4.tgz",
+      "integrity": "sha512-pjMZcNEt1dOq0aJCcY3b7w1Ayh+qmQN2xlfTELcGV9yiAjEGIczBPBLWWW0k0zzo5T8kiv15jtKPsWeHGxLvLg==",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/core": "2.0.0-beta.4",
         "zod": "^4.2.0"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -20,13 +20,13 @@
   },
   "dependencies": {
     "@cloudflare/workers-oauth-provider": "^0.8.0",
-    "@modelcontextprotocol/server": "2.0.0-beta.2",
+    "@modelcontextprotocol/server": "2.0.0-beta.4",
     "hono": "^4.12.25",
     "zod": "^4.3.5"
   },
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "^0.16.18",
-    "@modelcontextprotocol/client": "2.0.0-beta.2",
+    "@modelcontextprotocol/client": "2.0.0-beta.4",
     "@types/node": "^25.0.6",
     "msw": "^2.14.6",
     "oxfmt": "^0.31.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,83 +1,51 @@
-import OAuthProvider, { getOAuthApi } from '@cloudflare/workers-oauth-provider'
-import { Hono } from 'hono'
-import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/server'
-import { createServer } from './server'
+import OAuthProvider, {
+  getOAuthApi,
+  type OAuthProviderOptions
+} from '@cloudflare/workers-oauth-provider'
 import { createAuthHandlers, handleTokenExchangeCallback } from './auth/oauth-handler'
 import { isDirectApiToken, handleApiTokenRequest } from './auth/api-token-mode'
+import {
+  MCP_ROUTE,
+  handleAuthenticatedMcpRequest,
+  handleMcpPreflight,
+  oauthMcpHandler,
+  rejectInvalidMcpRequest
+} from './mcp-handler'
 import { processSpec, extractProducts } from './spec-processor'
 import { buildNonCodemodeTools, type OperationInfo } from './openapi'
-import type { AuthProps } from './auth/types'
 
 // GlobalOutbound lives with the execute tool (its only caller); wrangler
 // resolves the GLOBAL_OUTBOUND worker-loader entrypoint from this entry module,
 // so it must be re-exported here.
 export { GlobalOutbound } from './tools/execute'
 
-type McpContext = {
-  Bindings: Env
-}
-
-/**
- * Create an MCP response for the authenticated session described by `props`.
- */
-async function createMcpResponse(
-  request: Request,
-  ctx: ExecutionContext,
-  props: AuthProps
-): Promise<Response> {
-  const url = new URL(request.url)
-  const codemode = url.searchParams.get('codemode') !== 'false'
-  const server = await createServer(props, codemode)
-  const transport = new WebStandardStreamableHTTPServerTransport({
-    sessionIdGenerator: undefined,
-    enableJsonResponse: true,
-    retryInterval: 1000
-  })
-
-  await server.connect(transport)
-  const response = await transport.handleRequest(request)
-  ctx.waitUntil(transport.close())
-
-  return response
-}
-
-/**
- * Create MCP API handler using Hono
- */
-function createMcpHandler() {
-  const app = new Hono<McpContext>()
-
-  app.post('/mcp', async (c) => {
-    // Props are passed via ExecutionContext by workers-oauth-provider
-    const ctx = c.executionCtx as ExecutionContext & { props?: AuthProps }
-    const props = ctx.props
-    if (!props || !props.accessToken) {
-      return new Response(JSON.stringify({ error: 'Not authenticated' }), {
-        status: 401,
-        headers: { 'Content-Type': 'application/json' }
-      })
-    }
-    return createMcpResponse(c.req.raw, ctx, props)
-  })
-
-  return app
-}
-
 export default {
   async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+    const url = new URL(request.url)
+    const isMcpRoute = url.pathname === MCP_ROUTE
+    if (url.pathname.startsWith(MCP_ROUTE) && !isMcpRoute) {
+      return new Response('Not Found', { status: 404 })
+    }
+    if (isMcpRoute) {
+      // Validate Host and browser Origin before authentication so an invalid
+      // request cannot spend a bearer token on Cloudflare API identity probes.
+      const rejected = rejectInvalidMcpRequest(request)
+      if (rejected) return rejected
+      if (request.method === 'OPTIONS') return handleMcpPreflight(request)
+    }
+
     // Check for direct API token first (like GitHub MCP's PAT support)
-    if (isDirectApiToken(request)) {
+    if (isMcpRoute && isDirectApiToken(request)) {
       const response = await handleApiTokenRequest(request, (props) =>
-        createMcpResponse(request, ctx, props)
+        handleAuthenticatedMcpRequest(request, props)
       )
       if (response) return response
     }
 
     // OAuth mode - handle via workers-oauth-provider
-    const oauthOptions: ConstructorParameters<typeof OAuthProvider>[0] = {
+    const oauthOptions: OAuthProviderOptions<Env> = {
       apiHandlers: {
-        // @ts-ignore - Hono apps are compatible with ExportedHandler at runtime
-        '/mcp': createMcpHandler()
+        [MCP_ROUTE]: oauthMcpHandler
       },
       // @ts-ignore - Hono apps are compatible with ExportedHandler at runtime
       defaultHandler: createAuthHandlers(),

--- a/src/mcp-handler.ts
+++ b/src/mcp-handler.ts
@@ -1,4 +1,3 @@
-import { AsyncLocalStorage } from 'node:async_hooks'
 import {
   createMcpHandler,
   hostHeaderValidationResponse,
@@ -23,22 +22,16 @@ const ALLOWED_MCP_ORIGIN_HOSTNAMES = [
   'mcp.cloudflare.com'
 ]
 
-/** Request-local authenticated application context for the shared SDK handler. */
-const authPropsStorage = new AsyncLocalStorage<AuthProps>()
+function createAuthenticatedHandler(props: AuthProps) {
+  return createMcpHandler(({ requestInfo }) => {
+    if (!requestInfo) {
+      throw new Error('The Cloudflare MCP server requires an HTTP request')
+    }
 
-const handler = createMcpHandler(({ requestInfo }) => {
-  if (!requestInfo) {
-    throw new Error('The Cloudflare MCP server requires an HTTP request')
-  }
-
-  const props = authPropsStorage.getStore()
-  if (!props) {
-    throw new Error('Missing authenticated MCP request context')
-  }
-
-  const codemode = new URL(requestInfo.url).searchParams.get('codemode') !== 'false'
-  return createServer(props, codemode)
-})
+    const codemode = new URL(requestInfo.url).searchParams.get('codemode') !== 'false'
+    return createServer(props, codemode)
+  })
+}
 
 // Handler options are intentionally omitted. The SDK defaults to:
 // - stateless 2025 compatibility, with a fresh server and no protocol session
@@ -100,7 +93,8 @@ export async function handleAuthenticatedMcpRequest(
   if (rejected) return rejected
 
   const props = AuthPropsSchema.parse(rawProps)
-  return authPropsStorage.run(props, async () => withCors(await handler.fetch(request), request))
+  const handler = createAuthenticatedHandler(props)
+  return withCors(await handler.fetch(request), request)
 }
 
 /** ExportedHandler adapter required by workers-oauth-provider 0.8.x. */

--- a/src/mcp-handler.ts
+++ b/src/mcp-handler.ts
@@ -1,0 +1,111 @@
+import { AsyncLocalStorage } from 'node:async_hooks'
+import {
+  createMcpHandler,
+  hostHeaderValidationResponse,
+  localhostAllowedHostnames,
+  localhostAllowedOrigins,
+  originValidationResponse
+} from '@modelcontextprotocol/server'
+import { createServer } from './server'
+import { AuthProps as AuthPropsSchema, type AuthProps } from './auth/types'
+
+export const MCP_ROUTE = '/mcp'
+
+const ALLOWED_MCP_HOSTNAMES = [
+  ...localhostAllowedHostnames(),
+  'staging.mcp.cloudflare.com',
+  'mcp.cloudflare.com'
+]
+
+const ALLOWED_MCP_ORIGIN_HOSTNAMES = [
+  ...localhostAllowedOrigins(),
+  'staging.mcp.cloudflare.com',
+  'mcp.cloudflare.com'
+]
+
+/** Request-local authenticated application context for the shared SDK handler. */
+const authPropsStorage = new AsyncLocalStorage<AuthProps>()
+
+const handler = createMcpHandler(({ requestInfo }) => {
+  if (!requestInfo) {
+    throw new Error('The Cloudflare MCP server requires an HTTP request')
+  }
+
+  const props = authPropsStorage.getStore()
+  if (!props) {
+    throw new Error('Missing authenticated MCP request context')
+  }
+
+  const codemode = new URL(requestInfo.url).searchParams.get('codemode') !== 'false'
+  return createServer(props, codemode)
+})
+
+// Handler options are intentionally omitted. The SDK defaults to:
+// - stateless 2025 compatibility, with a fresh server and no protocol session
+// - automatic JSON/SSE response shaping (ordinary requests here remain JSON)
+
+/** Validate the deployment boundary before authentication or MCP dispatch. */
+export function rejectInvalidMcpRequest(request: Request): Response | undefined {
+  return (
+    hostHeaderValidationResponse(request, ALLOWED_MCP_HOSTNAMES) ??
+    originValidationResponse(request, ALLOWED_MCP_ORIGIN_HOSTNAMES)
+  )
+}
+
+function corsHeaders(request: Request): Headers | undefined {
+  const origin = request.headers.get('Origin')
+  if (!origin) return undefined
+
+  const requestedHeaders = request.headers.get('Access-Control-Request-Headers')
+  const headers = new Headers({
+    'Access-Control-Allow-Origin': origin,
+    'Access-Control-Allow-Methods': 'POST, OPTIONS',
+    'Access-Control-Allow-Headers':
+      requestedHeaders ??
+      'Content-Type, Accept, Authorization, MCP-Protocol-Version, Mcp-Method, Mcp-Name',
+    'Access-Control-Max-Age': '86400',
+    Vary: 'Origin'
+  })
+  return headers
+}
+
+function withCors(response: Response, request: Request): Response {
+  const cors = corsHeaders(request)
+  if (!cors) return response
+
+  const headers = new Headers(response.headers)
+  for (const [name, value] of cors) headers.set(name, value)
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers
+  })
+}
+
+/** Serve an allowed browser preflight without invoking authentication or a server factory. */
+export function handleMcpPreflight(request: Request): Response {
+  return new Response(null, { status: 204, headers: corsHeaders(request) })
+}
+
+/** Serve one authenticated MCP exchange with a fresh SDK v2 server instance. */
+export async function handleAuthenticatedMcpRequest(
+  request: Request,
+  rawProps: unknown
+): Promise<Response> {
+  if (new URL(request.url).pathname !== MCP_ROUTE) {
+    return new Response('Not Found', { status: 404 })
+  }
+
+  const rejected = rejectInvalidMcpRequest(request)
+  if (rejected) return rejected
+
+  const props = AuthPropsSchema.parse(rawProps)
+  return authPropsStorage.run(props, async () => withCors(await handler.fetch(request), request))
+}
+
+/** ExportedHandler adapter required by workers-oauth-provider 0.8.x. */
+export const oauthMcpHandler = {
+  fetch(request: Request, _env: Env, ctx: ExecutionContext) {
+    return handleAuthenticatedMcpRequest(request, ctx.props)
+  }
+}

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -16,11 +16,11 @@
  *
  * Note: this server is stateless (a fresh McpServer per request) so it does not
  * emit `session_start` events the way the Durable-Object-backed Cloudflare MCP
- * servers do — `oninitialized` fires on a separate request from `initialize`
- * and can never observe the client info. The `blob4`/`blob5`/`double2` slots
- * reserved upstream for session client info are simply left unused here, which
- * keeps shared-dataset queries compatible. Client identity is available at the
- * HTTP layer via the User-Agent header instead.
+ * servers do. MCP 2026-07-28 has no protocol session or initialize handshake;
+ * the 2025 compatibility path also retains no initialization state between
+ * requests. The slots reserved upstream for session client info remain unused,
+ * keeping shared-dataset queries compatible. Client identity is available at
+ * the HTTP layer via the User-Agent header instead.
  */
 
 import { env } from 'cloudflare:workers'
@@ -232,9 +232,9 @@ export function recordToolCall(props: AuthProps, toolName: string, isError: bool
  *
  * Note: unlike the Durable-Object-backed Cloudflare MCP servers, this server is
  * stateless (a fresh McpServer per request), so there is no meaningful
- * `session_start` to log — `oninitialized` fires on a separate request from the
- * `initialize` handshake and can never see the client info. Client identity is
- * instead available at the HTTP layer via the User-Agent header.
+ * `session_start` to log. Modern MCP has no initialize handshake, and the
+ * stateless 2025 fallback retains no client lifecycle between requests. Client
+ * identity is instead available at the HTTP layer via the User-Agent header.
  */
 export function attachMetrics(server: McpServer, props?: AuthProps): void {
   const metrics = new MetricsTracker(env.MCP_METRICS, SERVER_INFO)

--- a/tests/auth/oauth-routes.test.ts
+++ b/tests/auth/oauth-routes.test.ts
@@ -3,6 +3,7 @@ import { http, HttpResponse } from 'msw'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { cfAccountsSuccess, cfSuccess } from '../helpers/cloudflare-api'
 import { clearKv } from '../helpers/kv'
+import { modernMcpRequest, parseMcpResult } from '../helpers/mcp'
 import { server } from '../setup/msw'
 
 /**
@@ -18,11 +19,12 @@ import { server } from '../setup/msw'
  */
 
 const REDIRECT_URI = 'https://app.example.com/cb'
+const MCP_ORIGIN = 'https://mcp.cloudflare.com'
 
 /** Register a client via the provider's RFC 7591 endpoint; returns its id. */
 async function registerClient(): Promise<string> {
   const res = await exports.default.fetch(
-    new Request('https://mcp.example.com/register', {
+    new Request(`${MCP_ORIGIN}/register`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -36,12 +38,13 @@ async function registerClient(): Promise<string> {
 }
 
 function authorizeUrl(params: Record<string, string>): string {
-  const u = new URL('https://mcp.example.com/authorize')
+  const u = new URL(`${MCP_ORIGIN}/authorize`)
   for (const [k, v] of Object.entries(params)) u.searchParams.set(k, v)
   return u.toString()
 }
 
 async function beginAuthorization(options: { state?: string; scopes?: string } = {}): Promise<{
+  clientId: string
   state: string
   sessionCookie: string
   location: string
@@ -65,7 +68,7 @@ async function beginAuthorization(options: { state?: string; scopes?: string } =
   expect(stateField && csrfField).toBeTruthy()
 
   const postRes = await exports.default.fetch(
-    new Request('https://mcp.example.com/authorize', {
+    new Request(`${MCP_ORIGIN}/authorize`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/x-www-form-urlencoded', Cookie: csrfCookie },
       body: new URLSearchParams({
@@ -79,6 +82,7 @@ async function beginAuthorization(options: { state?: string; scopes?: string } =
   expect(postRes.status).toBe(302)
   const location = postRes.headers.get('location')!
   return {
+    clientId,
     state: new URL(location).searchParams.get('state')!,
     sessionCookie: cookiesFrom(postRes),
     location
@@ -195,7 +199,7 @@ describe('GET /oauth/callback', () => {
     // GET /oauth/callback -> 302 back to the client redirect URI with a code.
     const cbRes = await exports.default.fetch(
       new Request(
-        `https://mcp.example.com/oauth/callback?code=authcode&state=${encodeURIComponent(cfState)}`,
+        `${MCP_ORIGIN}/oauth/callback?code=authcode&state=${encodeURIComponent(cfState)}`,
         { headers: { Cookie: sessionCookie }, redirect: 'manual' }
       )
     )
@@ -216,6 +220,41 @@ describe('GET /oauth/callback', () => {
     expect(dp.blobs?.[3]).toBeFalsy()
   })
 
+  it('serves modern MCP from provider-issued authenticated props', async () => {
+    const { clientId, state, sessionCookie } = await beginAuthorization()
+    useCloudflareAuthSuccess()
+    const callback = await exports.default.fetch(
+      new Request(`${MCP_ORIGIN}/oauth/callback?code=authcode&state=${encodeURIComponent(state)}`, {
+        headers: { Cookie: sessionCookie },
+        redirect: 'manual'
+      })
+    )
+    const code = new URL(callback.headers.get('location')!).searchParams.get('code')
+    expect(code).toBeTruthy()
+
+    const tokenResponse = await exports.default.fetch(
+      new Request(`${MCP_ORIGIN}/token`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({
+          grant_type: 'authorization_code',
+          code: code!,
+          client_id: clientId,
+          redirect_uri: REDIRECT_URI
+        }).toString()
+      })
+    )
+    expect(tokenResponse.status).toBe(200)
+    const { access_token } = (await tokenResponse.json()) as { access_token: string }
+
+    const mcpResponse = await exports.default.fetch(modernMcpRequest(access_token, 'tools/list'))
+    const mcpBody = await parseMcpResult(mcpResponse)
+
+    expect(mcpResponse.status).toBe(200)
+    expect(mcpBody.result?.resultType).toBe('complete')
+    expect(mcpBody.result?.tools?.map((tool) => tool.name)).toEqual(['docs', 'search', 'execute'])
+  })
+
   it('preserves Unicode downstream client state without encoding it into upstream state', async () => {
     const downstreamState = 'client-state-🔐-你好'
     const { state, sessionCookie } = await beginAuthorization({ state: downstreamState })
@@ -223,10 +262,10 @@ describe('GET /oauth/callback', () => {
 
     useCloudflareAuthSuccess()
     const res = await exports.default.fetch(
-      new Request(
-        `https://mcp.example.com/oauth/callback?code=authcode&state=${encodeURIComponent(state)}`,
-        { headers: { Cookie: sessionCookie }, redirect: 'manual' }
-      )
+      new Request(`${MCP_ORIGIN}/oauth/callback?code=authcode&state=${encodeURIComponent(state)}`, {
+        headers: { Cookie: sessionCookie },
+        redirect: 'manual'
+      })
     )
 
     expect(res.status).toBe(302)
@@ -248,7 +287,7 @@ describe('GET /oauth/callback', () => {
 
     const res = await exports.default.fetch(
       new Request(
-        `https://mcp.example.com/oauth/callback?code=authcode&state=${encodeURIComponent(legacyState)}`,
+        `${MCP_ORIGIN}/oauth/callback?code=authcode&state=${encodeURIComponent(legacyState)}`,
         { headers: { Cookie: sessionCookie }, redirect: 'manual' }
       )
     )
@@ -263,10 +302,9 @@ describe('GET /oauth/callback', () => {
     const { state } = await beginAuthorization()
 
     const res = await exports.default.fetch(
-      new Request(
-        `https://mcp.example.com/oauth/callback?code=authcode&state=${encodeURIComponent(state)}`,
-        { redirect: 'manual' }
-      )
+      new Request(`${MCP_ORIGIN}/oauth/callback?code=authcode&state=${encodeURIComponent(state)}`, {
+        redirect: 'manual'
+      })
     )
 
     expect(res.status).toBe(400)
@@ -279,7 +317,7 @@ describe('GET /oauth/callback', () => {
 
     const res = await exports.default.fetch(
       new Request(
-        `https://mcp.example.com/oauth/callback?code=authcode&state=${encodeURIComponent(first.state)}`,
+        `${MCP_ORIGIN}/oauth/callback?code=authcode&state=${encodeURIComponent(first.state)}`,
         { headers: { Cookie: second.sessionCookie }, redirect: 'manual' }
       )
     )
@@ -291,7 +329,7 @@ describe('GET /oauth/callback', () => {
   it('rejects replay after a state token has completed authorization', async () => {
     const { state, sessionCookie } = await beginAuthorization()
     useCloudflareAuthSuccess()
-    const callbackUrl = `https://mcp.example.com/oauth/callback?code=authcode&state=${encodeURIComponent(state)}`
+    const callbackUrl = `${MCP_ORIGIN}/oauth/callback?code=authcode&state=${encodeURIComponent(state)}`
 
     const first = await exports.default.fetch(
       new Request(callbackUrl, { headers: { Cookie: sessionCookie }, redirect: 'manual' })
@@ -306,7 +344,7 @@ describe('GET /oauth/callback', () => {
   })
 
   it('returns 400 invalid_request when the code is missing', async () => {
-    const res = await exports.default.fetch(new Request('https://mcp.example.com/oauth/callback'))
+    const res = await exports.default.fetch(new Request(`${MCP_ORIGIN}/oauth/callback`))
 
     expect(res.status).toBe(400)
     expect(await res.text()).toContain('invalid_request')
@@ -314,7 +352,7 @@ describe('GET /oauth/callback', () => {
 
   it('logs an auth_user error when state is missing', async () => {
     const res = await exports.default.fetch(
-      new Request('https://mcp.example.com/oauth/callback?code=authcode')
+      new Request(`${MCP_ORIGIN}/oauth/callback?code=authcode`)
     )
 
     // No state -> validateOAuthState throws -> caught -> auth_user error logged.
@@ -328,10 +366,9 @@ describe('GET /oauth/callback', () => {
     ['oversized', 'x'.repeat(1024)]
   ])('rejects an %s state token as invalid_request', async (_, state) => {
     const res = await exports.default.fetch(
-      new Request(
-        `https://mcp.example.com/oauth/callback?code=authcode&state=${encodeURIComponent(state)}`,
-        { headers: { Cookie: '__Host-CONSENTED_STATE=deadbeef' } }
-      )
+      new Request(`${MCP_ORIGIN}/oauth/callback?code=authcode&state=${encodeURIComponent(state)}`, {
+        headers: { Cookie: '__Host-CONSENTED_STATE=deadbeef' }
+      })
     )
 
     expect(res.status).toBe(400)

--- a/tests/helpers/mcp.ts
+++ b/tests/helpers/mcp.ts
@@ -1,20 +1,32 @@
 import { exports } from 'cloudflare:workers'
 
-/** Result envelope of an MCP `tools/call` over Streamable HTTP. */
+export const MCP_URL = 'https://mcp.cloudflare.com/mcp'
+export const MCP_HOST = 'mcp.cloudflare.com'
+export const MODERN_MCP_VERSION = '2026-07-28'
+
+/** Result envelope of an MCP request over Streamable HTTP. */
 export interface McpToolResult {
   result?: {
+    resultType?: string
+    supportedVersions?: string[]
+    serverInfo?: { name: string; version: string }
     content?: Array<{ type: string; text: string }>
     isError?: boolean
-    tools?: Array<{ name: string; title?: string; annotations?: { title?: string; readOnlyHint?: boolean } }>
+    tools?: Array<{
+      name: string
+      title?: string
+      annotations?: { title?: string; readOnlyHint?: boolean }
+    }>
   }
   error?: { code: number; message: string }
 }
 
-/** Build a JSON-RPC `tools/list` request to the worker's `/mcp` endpoint. */
+/** Build a legacy JSON-RPC `tools/list` request to the worker's `/mcp` endpoint. */
 export function mcpToolListRequest(token: string, id = 1): Request {
-  return new Request('https://mcp.example.com/mcp', {
+  return new Request(MCP_URL, {
     method: 'POST',
     headers: {
+      Host: MCP_HOST,
       Authorization: `Bearer ${token}`,
       'Content-Type': 'application/json',
       Accept: 'application/json, text/event-stream'
@@ -23,16 +35,17 @@ export function mcpToolListRequest(token: string, id = 1): Request {
   })
 }
 
-/** Build a JSON-RPC `tools/call` request to the worker's `/mcp` endpoint. */
+/** Build a legacy JSON-RPC `tools/call` request to the worker's `/mcp` endpoint. */
 export function mcpToolCallRequest(
   token: string,
   name: string,
   args: Record<string, unknown>,
   id = 1
 ): Request {
-  return new Request('https://mcp.example.com/mcp', {
+  return new Request(MCP_URL, {
     method: 'POST',
     headers: {
+      Host: MCP_HOST,
       Authorization: `Bearer ${token}`,
       'Content-Type': 'application/json',
       // Streamable HTTP requires the client to accept both content types.
@@ -47,12 +60,58 @@ export function mcpToolCallRequest(
   })
 }
 
+/** Build an MCP 2026-07-28 request with its required per-request envelope. */
+export function modernMcpRequest(
+  token: string,
+  method: string,
+  params: Record<string, unknown> = {},
+  options: {
+    id?: number | string
+    url?: string
+    origin?: string
+    host?: string
+    headers?: Record<string, string>
+  } = {}
+): Request {
+  const name = typeof params.name === 'string' ? params.name : undefined
+  return new Request(options.url ?? MCP_URL, {
+    method: 'POST',
+    headers: {
+      Host: options.host ?? MCP_HOST,
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      Accept: 'application/json, text/event-stream',
+      'MCP-Protocol-Version': MODERN_MCP_VERSION,
+      'Mcp-Method': method,
+      ...(name && { 'Mcp-Name': name }),
+      ...(options.origin && { Origin: options.origin }),
+      ...options.headers
+    },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: options.id ?? 1,
+      method,
+      params: {
+        ...params,
+        _meta: {
+          'io.modelcontextprotocol/protocolVersion': MODERN_MCP_VERSION,
+          'io.modelcontextprotocol/clientInfo': {
+            name: 'cloudflare-mcp-tests',
+            version: '1.0.0'
+          },
+          'io.modelcontextprotocol/clientCapabilities': {}
+        }
+      }
+    })
+  })
+}
+
 /** Parse a Streamable HTTP response, which may be JSON or an SSE `data:` frame. */
 export async function parseMcpResult(res: Response): Promise<McpToolResult> {
   const text = await res.text()
   const contentType = res.headers.get('content-type') ?? ''
   if (contentType.includes('text/event-stream')) {
-    const dataLine = text.split('\n').find((l) => l.startsWith('data:'))
+    const dataLine = text.split('\n').find((line) => line.startsWith('data:'))
     return JSON.parse(dataLine!.slice('data:'.length).trim())
   }
   return JSON.parse(text)

--- a/tests/mcp-modern.test.ts
+++ b/tests/mcp-modern.test.ts
@@ -1,0 +1,343 @@
+import { env, exports } from 'cloudflare:workers'
+import { http, HttpResponse } from 'msw'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  API_BASE,
+  cfAccountsSuccess,
+  cfError,
+  cfSuccess,
+  mockIdentityProbe
+} from './helpers/cloudflare-api'
+import { clearKv } from './helpers/kv'
+import {
+  MCP_HOST,
+  MCP_URL,
+  mcpToolListRequest,
+  modernMcpRequest,
+  parseMcpResult
+} from './helpers/mcp'
+import { clearSpec, seedSpec } from './helpers/spec'
+import { server } from './setup/msw'
+
+const API_TOKEN = 'modern-mcp-token'
+const ACCOUNT_ID = '00000000000000000000000000000001'
+
+const SPEC_PATHS = {
+  '/accounts/{account_id}/workers/scripts': {
+    get: {
+      summary: 'List Workers',
+      tags: ['Workers'],
+      parameters: [{ name: 'account_id', in: 'path', required: true }],
+      responses: {}
+    }
+  }
+}
+
+beforeEach(async () => {
+  await seedSpec(SPEC_PATHS)
+  mockIdentityProbe({ accounts: [{ id: ACCOUNT_ID, name: 'Modern MCP' }] })
+})
+
+afterEach(async () => {
+  await clearKv(env.OAUTH_KV)
+  await clearSpec()
+})
+
+describe('MCP 2026-07-28 stateless handler', () => {
+  it('serves server/discover without creating a protocol session', async () => {
+    const response = await exports.default.fetch(modernMcpRequest(API_TOKEN, 'server/discover'))
+    const body = await parseMcpResult(response)
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toContain('application/json')
+    expect(response.headers.get('mcp-session-id')).toBeNull()
+    expect(body).toMatchObject({
+      result: {
+        resultType: 'complete',
+        supportedVersions: ['2026-07-28'],
+        serverInfo: { name: 'cloudflare-api', version: '0.1.0' }
+      }
+    })
+  })
+
+  it('serves modern tools/list with a complete result', async () => {
+    const response = await exports.default.fetch(modernMcpRequest(API_TOKEN, 'tools/list'))
+    const body = await parseMcpResult(response)
+
+    expect(response.status).toBe(200)
+    expect(body.result?.resultType).toBe('complete')
+    expect(body.result?.tools?.map((tool) => tool.name)).toEqual(['docs', 'search', 'execute'])
+  })
+
+  it('serves a modern Code Mode tools/call', async () => {
+    server.use(
+      http.get(`${API_BASE}/accounts/${ACCOUNT_ID}/tokens/verify`, () =>
+        HttpResponse.json(cfSuccess({ id: 'token-1', status: 'active' }))
+      )
+    )
+    const code = `async () => cloudflare.request({ method: "GET", path: "/accounts/${ACCOUNT_ID}/tokens/verify" })`
+
+    const response = await exports.default.fetch(
+      modernMcpRequest(API_TOKEN, 'tools/call', {
+        name: 'execute',
+        arguments: { code }
+      })
+    )
+    const body = await parseMcpResult(response)
+
+    expect(response.status).toBe(200)
+    expect(body.result?.resultType).toBe('complete')
+    expect(body.result?.isError).toBeFalsy()
+    expect(body.result?.content?.[0]?.text).toContain('"status": "active"')
+  })
+
+  it('serves a modern non-Code-Mode tools/call', async () => {
+    server.use(
+      http.get(`${API_BASE}/accounts/${ACCOUNT_ID}/workers/scripts`, () =>
+        HttpResponse.json(cfSuccess([{ id: 'worker-a' }]))
+      )
+    )
+
+    const response = await exports.default.fetch(
+      modernMcpRequest(
+        API_TOKEN,
+        'tools/call',
+        {
+          name: 'get_accounts_workers_scripts',
+          arguments: {}
+        },
+        { url: `${MCP_URL}?codemode=false` }
+      )
+    )
+    const body = await parseMcpResult(response)
+
+    expect(response.status).toBe(200)
+    expect(body.result?.resultType).toBe('complete')
+    expect(body.result?.isError).toBeFalsy()
+    expect(body.result?.content?.[0]?.text).toContain('worker-a')
+  })
+
+  it('isolates authenticated props across concurrent requests', async () => {
+    const firstAccount = '00000000000000000000000000000002'
+    const secondAccount = '00000000000000000000000000000003'
+    server.use(
+      http.get(`${API_BASE}/user`, () => HttpResponse.json(cfError([], null))),
+      http.get(`${API_BASE}/accounts`, ({ request }) => {
+        const account =
+          request.headers.get('Authorization') === 'Bearer token-a'
+            ? { id: firstAccount, name: 'First' }
+            : { id: secondAccount, name: 'Second' }
+        return HttpResponse.json(cfAccountsSuccess([account]))
+      }),
+      http.get(`${API_BASE}/accounts/${firstAccount}/workers/scripts`, () =>
+        HttpResponse.json(cfSuccess([{ id: 'first-worker' }]))
+      ),
+      http.get(`${API_BASE}/accounts/${secondAccount}/workers/scripts`, () =>
+        HttpResponse.json(cfSuccess([{ id: 'second-worker' }]))
+      )
+    )
+    const request = (token: string, id: number) =>
+      modernMcpRequest(
+        token,
+        'tools/call',
+        { name: 'get_accounts_workers_scripts', arguments: {} },
+        { id, url: `${MCP_URL}?codemode=false` }
+      )
+
+    const [firstResponse, secondResponse] = await Promise.all([
+      exports.default.fetch(request('token-a', 1)),
+      exports.default.fetch(request('token-b', 2))
+    ])
+    const [first, second] = await Promise.all([
+      parseMcpResult(firstResponse),
+      parseMcpResult(secondResponse)
+    ])
+
+    expect(first.result?.content?.[0]?.text).toContain('first-worker')
+    expect(first.result?.content?.[0]?.text).not.toContain('second-worker')
+    expect(second.result?.content?.[0]?.text).toContain('second-worker')
+    expect(second.result?.content?.[0]?.text).not.toContain('first-worker')
+  })
+
+  it('isolates concurrent factories with different requested tool surfaces', async () => {
+    const [codemodeResponse, endpointResponse] = await Promise.all([
+      exports.default.fetch(modernMcpRequest(API_TOKEN, 'tools/list', {}, { id: 1 })),
+      exports.default.fetch(
+        modernMcpRequest(
+          API_TOKEN,
+          'tools/list',
+          {},
+          {
+            id: 2,
+            url: `${MCP_URL}?codemode=false`
+          }
+        )
+      )
+    ])
+    const [codemode, endpoints] = await Promise.all([
+      parseMcpResult(codemodeResponse),
+      parseMcpResult(endpointResponse)
+    ])
+
+    expect(codemodeResponse.status).toBe(200)
+    expect(endpointResponse.status).toBe(200)
+    expect(codemode.result?.tools?.map((tool) => tool.name)).toEqual(['docs', 'search', 'execute'])
+    expect(endpoints.result?.tools?.map((tool) => tool.name)).toEqual([
+      'docs',
+      'get_accounts_workers_scripts'
+    ])
+    expect(codemodeResponse.headers.get('mcp-session-id')).toBeNull()
+    expect(endpointResponse.headers.get('mcp-session-id')).toBeNull()
+  })
+
+  it('rejects a mismatched modern method header', async () => {
+    const response = await exports.default.fetch(
+      modernMcpRequest(
+        API_TOKEN,
+        'tools/list',
+        {},
+        {
+          headers: { 'Mcp-Method': 'tools/call' }
+        }
+      )
+    )
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toMatchObject({
+      error: { message: expect.stringContaining('Mcp-Method') },
+      id: 1,
+      jsonrpc: '2.0'
+    })
+  })
+
+  it('retains stateless 2025 compatibility by default', async () => {
+    const response = await exports.default.fetch(mcpToolListRequest(API_TOKEN))
+    const body = await parseMcpResult(response)
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toContain('text/event-stream')
+    expect(response.headers.get('mcp-session-id')).toBeNull()
+    expect(body.result?.tools?.map((tool) => tool.name)).toEqual(['docs', 'search', 'execute'])
+  })
+
+  it.each(['GET', 'DELETE'])('rejects session-only %s requests', async (method) => {
+    const response = await exports.default.fetch(
+      new Request(MCP_URL, {
+        method,
+        headers: {
+          Host: MCP_HOST,
+          Authorization: `Bearer ${API_TOKEN}`,
+          Accept: 'application/json, text/event-stream'
+        }
+      })
+    )
+
+    expect(response.status).toBe(405)
+    expect(await response.json()).toMatchObject({
+      error: { code: -32000, message: 'Method not allowed.' },
+      id: null,
+      jsonrpc: '2.0'
+    })
+  })
+
+  it('keeps session-only methods behind bearer authentication', async () => {
+    const response = await exports.default.fetch(
+      new Request(MCP_URL, {
+        method: 'GET',
+        headers: { Host: MCP_HOST, Accept: 'application/json, text/event-stream' }
+      })
+    )
+
+    expect(response.status).toBe(401)
+    expect(await response.json()).toMatchObject({ error: 'invalid_token' })
+  })
+})
+
+describe('MCP deployment boundary', () => {
+  it('does not treat longer path prefixes as the MCP endpoint', async () => {
+    const response = await exports.default.fetch(
+      modernMcpRequest(API_TOKEN, 'server/discover', {}, { url: `${MCP_URL}/other` })
+    )
+
+    expect(response.status).toBe(404)
+  })
+
+  it('allows the production Host and same-host browser Origin', async () => {
+    const response = await exports.default.fetch(
+      modernMcpRequest(API_TOKEN, 'server/discover', {}, { origin: `https://${MCP_HOST}` })
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('access-control-allow-origin')).toBe(`https://${MCP_HOST}`)
+    expect(response.headers.get('vary')).toContain('Origin')
+  })
+
+  it('rejects an unlisted browser Origin before probing the bearer token', async () => {
+    let identityProbeCalls = 0
+    server.use(
+      http.get(`${API_BASE}/user`, () => {
+        identityProbeCalls++
+        return HttpResponse.json(cfSuccess(null))
+      }),
+      http.get(`${API_BASE}/accounts`, () => {
+        identityProbeCalls++
+        return HttpResponse.json(cfSuccess([]))
+      })
+    )
+
+    const response = await exports.default.fetch(
+      modernMcpRequest(
+        API_TOKEN,
+        'server/discover',
+        {},
+        {
+          origin: 'https://attacker.example'
+        }
+      )
+    )
+
+    expect(response.status).toBe(403)
+    expect(identityProbeCalls).toBe(0)
+  })
+
+  it('does not derive trust from an attacker-controlled matching Host and Origin', async () => {
+    const response = await exports.default.fetch(
+      modernMcpRequest(
+        API_TOKEN,
+        'server/discover',
+        {},
+        {
+          url: 'https://attacker.example/mcp',
+          host: 'attacker.example',
+          origin: 'https://attacker.example'
+        }
+      )
+    )
+
+    expect(response.status).toBe(403)
+    expect(await response.json()).toMatchObject({
+      error: { message: expect.stringContaining('Invalid Host') }
+    })
+  })
+
+  it('serves modern CORS preflight headers without authentication', async () => {
+    const response = await exports.default.fetch(
+      new Request(MCP_URL, {
+        method: 'OPTIONS',
+        headers: {
+          Host: MCP_HOST,
+          Origin: `https://${MCP_HOST}`,
+          'Access-Control-Request-Method': 'POST',
+          'Access-Control-Request-Headers':
+            'authorization, content-type, mcp-method, mcp-name, mcp-param-account-id'
+        }
+      })
+    )
+
+    expect(response.status).toBe(204)
+    expect(response.headers.get('access-control-allow-origin')).toBe(`https://${MCP_HOST}`)
+    expect(response.headers.get('access-control-allow-headers')).toBe(
+      'authorization, content-type, mcp-method, mcp-name, mcp-param-account-id'
+    )
+  })
+})

--- a/tests/metrics.test.ts
+++ b/tests/metrics.test.ts
@@ -11,7 +11,7 @@ import {
 import { API_BASE, cfSuccess, mockIdentityProbe } from './helpers/cloudflare-api'
 import { clearKv } from './helpers/kv'
 import { clearSpec, seedSpec } from './helpers/spec'
-import { callTool, mcpToolCallRequest, parseMcpResult } from './helpers/mcp'
+import { MCP_URL, callTool, mcpToolCallRequest, parseMcpResult } from './helpers/mcp'
 import { server } from './setup/msw'
 
 const SERVER_INFO = { name: 'cloudflare-api', version: '0.1.0' }
@@ -151,7 +151,7 @@ describe('tool_call emission via the real worker', () => {
     mockIdentityProbe({ accounts: [{ id: ACCOUNT_ID, name: 'Acc' }] })
     const writeSpy = vi.spyOn(env.MCP_METRICS, 'writeDataPoint')
     const base = mcpToolCallRequest(API_TOKEN, 'get_accounts', {})
-    const request = new Request('https://mcp.example.com/mcp?codemode=false', base)
+    const request = new Request(`${MCP_URL}?codemode=false`, base)
 
     const result = await parseMcpResult(await exports.default.fetch(request))
 

--- a/tests/non-codemode-worker.test.ts
+++ b/tests/non-codemode-worker.test.ts
@@ -4,7 +4,13 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { API_BASE, cfSuccess, mockIdentityProbe } from './helpers/cloudflare-api'
 import { clearKv } from './helpers/kv'
 import { clearSpec, seedSpec } from './helpers/spec'
-import { mcpToolCallRequest, mcpToolListRequest, parseMcpResult, toolText } from './helpers/mcp'
+import {
+  MCP_URL,
+  mcpToolCallRequest,
+  mcpToolListRequest,
+  parseMcpResult,
+  toolText
+} from './helpers/mcp'
 import { server } from './setup/msw'
 
 /**
@@ -46,7 +52,7 @@ const SPEC_PATHS = {
 /** POST a non-codemode tools/list to the real worker. */
 async function listNonCodemodeTools(token: string) {
   const base = mcpToolListRequest(token)
-  const req = new Request('https://mcp.example.com/mcp?codemode=false', base)
+  const req = new Request(`${MCP_URL}?codemode=false`, base)
   const result = (await parseMcpResult(await exports.default.fetch(req))) as unknown as {
     result?: {
       tools?: Array<{
@@ -62,7 +68,7 @@ async function listNonCodemodeTools(token: string) {
 /** POST a non-codemode tools/call to the real worker. */
 async function callNonCodemodeTool(token: string, name: string, args: Record<string, unknown>) {
   const base = mcpToolCallRequest(token, name, args)
-  const req = new Request('https://mcp.example.com/mcp?codemode=false', base)
+  const req = new Request(`${MCP_URL}?codemode=false`, base)
   return parseMcpResult(await exports.default.fetch(req))
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "lib": ["ES2022"],
-    "types": ["./worker-configuration.d.ts", "@cloudflare/vitest-pool-workers/types", "node"],
+    "types": ["./worker-configuration.d.ts", "@cloudflare/vitest-pool-workers/types"],
     "strict": true,
     "skipLibCheck": true,
     "noEmit": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "lib": ["ES2022"],
-    "types": ["./worker-configuration.d.ts", "@cloudflare/vitest-pool-workers/types"],
+    "types": ["./worker-configuration.d.ts", "@cloudflare/vitest-pool-workers/types", "node"],
     "strict": true,
     "skipLibCheck": true,
     "noEmit": true,


### PR DESCRIPTION
## Summary

- upgrade the split MCP TypeScript SDK client/server pins from `2.0.0-beta.2` to the latest published `2.0.0-beta.4`
- replace the hand-wired raw Streamable HTTP transport with `createMcpHandler(factory)` directly from `@modelcontextprotocol/server`
- serve MCP `2026-07-28` from a fresh server per request while retaining the SDK's default stateless 2025 compatibility path
- preserve OAuth and direct Cloudflare API-token authentication without adding an Agents SDK dependency
- validate deployment-static Host and browser Origin allowlists before authentication, and serve modern CORS preflights
- keep OAuth/KV/R2/Analytics Engine/Worker Loader application state while retaining no MCP session, transport, or replay state

Each authenticated request creates a TypeScript SDK handler whose factory closes over its validated `AuthProps`, preserving the explicit `props -> createServer(props)` data flow used before this migration. No Node ambient types, `AsyncLocalStorage`, or implicit global auth state is required.

One response-shaping detail is intentional: ordinary modern requests return JSON under the SDK's `responseMode: "auto"`; claimless stateless 2025 requests use the upstream SSE response shape. Both paths issue no `Mcp-Session-Id`.

## Validation

- `npm ci`
- `npm run check` — 17 test files / 289 tests
- `npm ls @modelcontextprotocol/server @modelcontextprotocol/client @modelcontextprotocol/core --depth=1`
- `npm audit --omit=dev` — 0 vulnerabilities
- production upload — 1294.29 KiB raw / 242.92 KiB gzip, 120 ms startup

Coverage includes modern discovery/list/call, Code Mode and non-Code-Mode dispatch, concurrent auth and factory isolation, stateless 2025 fallback, GET/DELETE rejection, OAuth-issued tokens, Host/Origin rejection, and CORS preflights.

## Production rollout

Deployed from runtime commit `ba95888`:

- Worker version: `bca4d618-2eab-429b-a62a-71623c98c55e`
- public OAuth metadata: pass
- unauthenticated `/mcp` guard: pass (`401`)
- same-origin CORS preflight: pass (`204`)
- hostile browser Origin rejection: pass (`403`)
- modern `server/discover`: pass, no session ID
- modern `tools/list`: pass, no session ID
- modern Code Mode `execute` read (`GET /user`): pass
- modern non-Code-Mode `get_user`: pass
- stateless legacy Code Mode read: pass, SSE, no session ID
- authenticated legacy GET rejection: pass (`405`)

The Wrangler token was read in-memory for smoke tests and was not printed or persisted.
