### PR TITLE
feat: pin OAuth tokens to the canonical MCP resource

### DIFF
--- a/src/auth/api-token-mode.ts
+++ b/src/auth/api-token-mode.ts
@@ -120,7 +120,12 @@ export async function resolveExternalToken({
   const tokenOwner = cloudflareTokenOwner(token)
   try {
     const identity = await getCachedIdentity(token, tokenOwner, env.OAUTH_KV)
-    return { props: buildAuthProps(token, identity) }
+    return {
+      props: buildAuthProps(token, identity),
+      // Cloudflare API tokens are opaque credentials, so successful identity
+      // validation establishes their local protected-resource audience.
+      audience: env.MCP_RESOURCE
+    }
   } catch (error) {
     if (error instanceof OAuthError) throw externalTokenError(error, tokenOwner)
     throw error

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,6 +56,7 @@ export default {
           () => getOAuthApi(oauthOptions, env)
         ),
       resourceMetadata: {
+        resource: env.MCP_RESOURCE,
         resource_name: 'Cloudflare API MCP Server'
       },
       accessTokenTTL: 3600,

--- a/tests/auth/api-token-mode.test.ts
+++ b/tests/auth/api-token-mode.test.ts
@@ -131,7 +131,8 @@ describe('resolveExternalToken', () => {
         type: 'account_token',
         accessToken: 'cfat_account-token',
         account: ACCOUNT
-      }
+      },
+      audience: env.MCP_RESOURCE
     })
     expect(calls.userCalls()).toBe(0)
     expect(calls.accountCalls()).toBe(1)
@@ -146,7 +147,8 @@ describe('resolveExternalToken', () => {
       })
 
       await expect(resolveExternalToken(resolverInput(token))).resolves.toMatchObject({
-        props: { type: 'user_token', accessToken: token, user: USER, accounts: [ACCOUNT] }
+        props: { type: 'user_token', accessToken: token, user: USER, accounts: [ACCOUNT] },
+        audience: env.MCP_RESOURCE
       })
       expect(calls.userCalls()).toBe(1)
       expect(calls.accountCalls()).toBe(1)

--- a/tests/auth/oauth-routes.test.ts
+++ b/tests/auth/oauth-routes.test.ts
@@ -21,6 +21,7 @@ import { server } from '../setup/msw'
 
 const REDIRECT_URI = 'https://app.example.com/cb'
 const MCP_ORIGIN = 'https://mcp.cloudflare.com'
+const MCP_RESOURCE = `${MCP_ORIGIN}/mcp`
 const DOWNSTREAM_CODE_VERIFIER = 'test-downstream-code-verifier'
 const DOWNSTREAM_CODE_CHALLENGE = 'I4fhllfHqqQsgap17V2SDI0scSei8H7U0e0rZBDIcbo'
 
@@ -42,6 +43,7 @@ async function registerClient(): Promise<string> {
 
 function authorizeUrl(params: Record<string, string>): string {
   const u = new URL(`${MCP_ORIGIN}/authorize`)
+  u.searchParams.set('resource', MCP_RESOURCE)
   for (const [k, v] of Object.entries(params)) u.searchParams.set(k, v)
   u.searchParams.set('code_challenge', DOWNSTREAM_CODE_CHALLENGE)
   u.searchParams.set('code_challenge_method', 'S256')
@@ -73,6 +75,7 @@ async function beginAuthorization(options: { state?: string; scopes?: string } =
         response_type: 'code',
         client_id: clientId,
         redirect_uri: REDIRECT_URI,
+        resource: MCP_RESOURCE,
         code_challenge: DOWNSTREAM_CODE_CHALLENGE,
         code_challenge_method: 'S256',
         scope: options.scopes ?? 'user:read',
@@ -163,6 +166,29 @@ afterEach(async () => {
   await clearKv(env.OAUTH_KV)
 })
 
+describe('OAuth metadata policy', () => {
+  it('advertises the canonical MCP endpoint as the protected resource', async () => {
+    const response = await exports.default.fetch(
+      new Request(`${MCP_ORIGIN}/.well-known/oauth-protected-resource/mcp`)
+    )
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({ resource: MCP_RESOURCE })
+  })
+
+  it('advertises RFC 9207 authorization response issuer support', async () => {
+    const response = await exports.default.fetch(
+      new Request(`${MCP_ORIGIN}/.well-known/oauth-authorization-server`)
+    )
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      issuer: MCP_ORIGIN,
+      authorization_response_iss_parameter_supported: true
+    })
+  })
+})
+
 describe('GET /authorize', () => {
   it('renders the consent dialog for a registered client', async () => {
     const clientId = await registerClient()
@@ -173,6 +199,7 @@ describe('GET /authorize', () => {
           response_type: 'code',
           client_id: clientId,
           redirect_uri: REDIRECT_URI,
+          resource: MCP_RESOURCE,
           code_challenge: DOWNSTREAM_CODE_CHALLENGE,
           code_challenge_method: 'S256',
           scope: 'user:read'
@@ -226,6 +253,32 @@ describe('GET /authorize', () => {
       'offline_access',
       'account:read'
     ])
+  })
+
+  it('rejects a resource other than the canonical MCP endpoint', async () => {
+    const clientId = await registerClient()
+    const response = await exports.default.fetch(
+      new Request(
+        authorizeUrl({
+          response_type: 'code',
+          client_id: clientId,
+          redirect_uri: REDIRECT_URI,
+          resource: MCP_ORIGIN,
+          state: 'client-state'
+        })
+      ),
+      { redirect: 'manual' }
+    )
+
+    expect(response.status).toBe(302)
+    const redirect = new URL(response.headers.get('location')!)
+    expect(redirect.origin + redirect.pathname).toBe(REDIRECT_URI)
+    expect(redirect.searchParams.get('error')).toBe('invalid_request')
+    expect(redirect.searchParams.get('state')).toBe('client-state')
+    expect(redirect.searchParams.get('iss')).toBe(MCP_ORIGIN)
+    expect(response.headers.get('cache-control')).toBe('no-store')
+    expect(writtenEvents(metricsSpy)).not.toContain('auth_user')
+    expect((await env.OAUTH_KV.list({ prefix: 'grant:' })).keys).toHaveLength(0)
   })
 
   it('rejects unknown requested scopes instead of silently downgrading them', async () => {
@@ -338,6 +391,7 @@ describe('GET /authorize', () => {
       response_type: 'code',
       client_id: clientId,
       redirect_uri: REDIRECT_URI,
+      resource: MCP_RESOURCE,
       state: 'client-state'
     }).toString()
     const response = await exports.default.fetch(new Request(url), { redirect: 'manual' })
@@ -381,6 +435,7 @@ describe('GET /authorize', () => {
           response_type: 'code',
           client_id: 'does-not-exist',
           redirect_uri: REDIRECT_URI,
+          resource: MCP_RESOURCE,
           code_challenge: DOWNSTREAM_CODE_CHALLENGE,
           code_challenge_method: 'S256'
         })
@@ -466,6 +521,7 @@ describe('GET /oauth/callback', () => {
     const redirect = new URL(cbRes.headers.get('location')!)
     expect(redirect.origin + redirect.pathname).toBe(REDIRECT_URI)
     expect(redirect.searchParams.get('code')).toBeTruthy()
+    expect(redirect.searchParams.get('iss')).toBe(MCP_ORIGIN)
 
     // A successful login records an auth_user datapoint with the userId (blob3)
     // and no error message (blob4).
@@ -497,17 +553,28 @@ describe('GET /oauth/callback', () => {
     const code = new URL(callback.headers.get('location')!).searchParams.get('code')
     expect(code).toBeTruthy()
 
+    const tokenParams = {
+      grant_type: 'authorization_code',
+      code: code!,
+      client_id: clientId,
+      redirect_uri: REDIRECT_URI,
+      code_verifier: DOWNSTREAM_CODE_VERIFIER
+    }
+    const missingResourceResponse = await exports.default.fetch(
+      new Request(`${MCP_ORIGIN}/token`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams(tokenParams).toString()
+      })
+    )
+    expect(missingResourceResponse.status).toBe(400)
+    await expect(missingResourceResponse.json()).resolves.toMatchObject({ error: 'invalid_target' })
+
     const tokenResponse = await exports.default.fetch(
       new Request(`${MCP_ORIGIN}/token`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-        body: new URLSearchParams({
-          grant_type: 'authorization_code',
-          code: code!,
-          client_id: clientId,
-          redirect_uri: REDIRECT_URI,
-          code_verifier: DOWNSTREAM_CODE_VERIFIER
-        }).toString()
+        body: new URLSearchParams({ ...tokenParams, resource: MCP_RESOURCE }).toString()
       })
     )
     expect(tokenResponse.status).toBe(200)
@@ -538,7 +605,8 @@ describe('GET /oauth/callback', () => {
           code: code!,
           client_id: clientId,
           redirect_uri: REDIRECT_URI,
-          code_verifier: DOWNSTREAM_CODE_VERIFIER
+          code_verifier: DOWNSTREAM_CODE_VERIFIER,
+          resource: MCP_RESOURCE
         }).toString()
       })
     )

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,7 +11,8 @@ export default defineConfig({
         bindings: {
           MCP_COOKIE_ENCRYPTION_KEY: 'test-cookie-encryption-key-0000000000000000',
           CLOUDFLARE_CLIENT_ID: 'test-client-id',
-          CLOUDFLARE_CLIENT_SECRET: 'test-client-secret'
+          CLOUDFLARE_CLIENT_SECRET: 'test-client-secret',
+          MCP_RESOURCE: 'https://mcp.cloudflare.com/mcp'
         }
       }
     })

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -13,6 +13,7 @@ declare namespace Cloudflare {
 		AI: Ai;
 		CLOUDFLARE_API_BASE: "https://api.staging.cloudflare.com/client/v4";
 		CLOUDFLARE_OAUTH_DOMAIN: "https://dash.staging.cloudflare.com";
+		MCP_RESOURCE: "https://staging.mcp.cloudflare.com/mcp";
 		OPENAPI_SPEC_URL: "https://raw.githubusercontent.com/cloudflare/api-schemas/main/openapi.json";
 		MCP_COOKIE_ENCRYPTION_KEY: string;
 		CLOUDFLARE_CLIENT_ID: string;
@@ -28,6 +29,7 @@ declare namespace Cloudflare {
 		AI: Ai;
 		CLOUDFLARE_API_BASE: "https://api.cloudflare.com/client/v4";
 		CLOUDFLARE_OAUTH_DOMAIN: "https://dash.cloudflare.com";
+		MCP_RESOURCE: "https://mcp.cloudflare.com/mcp";
 		OPENAPI_SPEC_URL: "https://raw.githubusercontent.com/cloudflare/api-schemas/main/openapi.json";
 		MCP_COOKIE_ENCRYPTION_KEY: string;
 		CLOUDFLARE_CLIENT_ID: string;
@@ -47,6 +49,7 @@ declare namespace Cloudflare {
 		AI?: Ai;
 		CLOUDFLARE_API_BASE: "https://api.staging.cloudflare.com/client/v4" | "https://api.cloudflare.com/client/v4";
 		CLOUDFLARE_OAUTH_DOMAIN: "https://dash.staging.cloudflare.com" | "https://dash.cloudflare.com";
+		MCP_RESOURCE: "https://staging.mcp.cloudflare.com/mcp" | "https://mcp.cloudflare.com/mcp" | "http://localhost:2529/mcp";
 		OPENAPI_SPEC_URL: "https://raw.githubusercontent.com/cloudflare/api-schemas/main/openapi.json";
 		GLOBAL_OUTBOUND: Service /* entrypoint GlobalOutbound from cloudflare-api-mcp-staging */ | Service /* entrypoint GlobalOutbound from cloudflare-api-mcp */ | Service<typeof import("./src/index").GlobalOutbound>;
 	}
@@ -56,7 +59,7 @@ type StringifyValues<EnvType extends Record<string, unknown>> = {
 	[Binding in keyof EnvType]: EnvType[Binding] extends string ? EnvType[Binding] : string;
 };
 declare namespace NodeJS {
-	interface ProcessEnv extends StringifyValues<Pick<Cloudflare.Env, "CLOUDFLARE_API_BASE" | "CLOUDFLARE_OAUTH_DOMAIN" | "OPENAPI_SPEC_URL" | "MCP_COOKIE_ENCRYPTION_KEY" | "CLOUDFLARE_CLIENT_ID" | "CLOUDFLARE_CLIENT_SECRET" | "CLOUDFLARE_API_KEY">> {}
+	interface ProcessEnv extends StringifyValues<Pick<Cloudflare.Env, "CLOUDFLARE_API_BASE" | "CLOUDFLARE_OAUTH_DOMAIN" | "MCP_RESOURCE" | "OPENAPI_SPEC_URL" | "MCP_COOKIE_ENCRYPTION_KEY" | "CLOUDFLARE_CLIENT_ID" | "CLOUDFLARE_CLIENT_SECRET" | "CLOUDFLARE_API_KEY">> {}
 }
 
 // Begin runtime types

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -18,6 +18,7 @@
 	"vars": {
 		"CLOUDFLARE_API_BASE": "https://api.cloudflare.com/client/v4",
 		"CLOUDFLARE_OAUTH_DOMAIN": "https://dash.cloudflare.com",
+		"MCP_RESOURCE": "http://localhost:2529/mcp",
 		"OPENAPI_SPEC_URL": "https://raw.githubusercontent.com/cloudflare/api-schemas/main/openapi.json"
 	},
 	"worker_loaders": [
@@ -103,6 +104,7 @@
 			"vars": {
 				"CLOUDFLARE_API_BASE": "https://api.staging.cloudflare.com/client/v4",
 				"CLOUDFLARE_OAUTH_DOMAIN": "https://dash.staging.cloudflare.com",
+				"MCP_RESOURCE": "https://staging.mcp.cloudflare.com/mcp",
 				"OPENAPI_SPEC_URL": "https://raw.githubusercontent.com/cloudflare/api-schemas/main/openapi.json"
 			}
 		},
@@ -153,6 +155,7 @@
 			"vars": {
 				"CLOUDFLARE_API_BASE": "https://api.cloudflare.com/client/v4",
 				"CLOUDFLARE_OAUTH_DOMAIN": "https://dash.cloudflare.com",
+				"MCP_RESOURCE": "https://mcp.cloudflare.com/mcp",
 				"OPENAPI_SPEC_URL": "https://raw.githubusercontent.com/cloudflare/api-schemas/main/openapi.json"
 			}
 		}


### PR DESCRIPTION
## Summary

Pin OAuth authorization grants, provider-issued access tokens, and direct Cloudflare OAuth credentials to the canonical Cloudflare MCP endpoint.

- configure an explicit `MCP_RESOURCE` for local, staging, and production
- pass that exact endpoint through `resourceMetadata.resource`
- require it in authorization and token requests
- use it as the audience when validating direct Cloudflare OAuth tokens
- preserve RFC 9207 authorization-response issuer (`iss`) behavior
- update the integration suite for exact-resource and PKCE flows

Canonical resources:

- local: `http://localhost:2529/mcp`
- staging: `https://staging.mcp.cloudflare.com/mcp`
- production: `https://mcp.cloudflare.com/mcp`

## Validation

- `npm ci`
- `npm run check` — 19 test files, 256 tests; formatting, lint, types, and tests all pass
- GitHub CI, CodeQL, and Semgrep all pass

The OAuth integration coverage verifies:

- protected-resource metadata returns the canonical `/mcp` resource
- authorization-server metadata advertises RFC 9207 issuer support
- successful authorization responses include the expected `iss`
- authorization rejects a broader origin resource
- token exchange rejects an omitted resource without consuming the code
- retrying that code with the exact resource succeeds
- direct Cloudflare OAuth credentials use the exact MCP endpoint as their audience

## Staging

Deployed to `cloudflare-api-mcp-staging`:

- URL: `https://staging.mcp.cloudflare.com/mcp`
- Worker version: `e0adfb78-5dd9-46cb-928e-9e91f60d7bb3`

Deployed metadata, bearer challenge, exact-resource authorization, and rejection of omitted/broader resources were smoke-tested successfully.

## Live MCP client E2E

Each client completed browser OAuth against staging, connected to the MCP server, and made a real `search` tool call that returned `{ "exists": true }`:

| Client | Version | Registration | Result |
| --- | --- | --- | --- |
| Claude Code | 2.1.221 | DCR | PASS |
| Codex CLI | 0.147.0-alpha.6 | DCR | PASS |
| OpenCode | 1.14.18 | DCR | PASS |
| Pi | 0.82.1 with `pi-mcp-adapter` 2.11.0 | DCR | PASS |

Temporary test registrations, credentials, sessions, and local client configuration were removed after the runs.

Client ID Metadata Documents remain disabled in this PR and are handled in a separate stacked follow-up.
