### PR TITLE
Add Realtime read OAuth scope

### DIFF
--- a/src/auth/derived-oauth-scopes.json
+++ b/src/auth/derived-oauth-scopes.json
@@ -1079,6 +1079,10 @@
     "category": "Developer Platform",
     "name": "Realtime Admin"
   },
+  "realtime.read": {
+    "category": "Developer Platform",
+    "name": "Realtime Read"
+  },
   "realtime.write": {
     "category": "Developer Platform",
     "name": "Realtime"

--- a/tests/auth/oauth-routes.test.ts
+++ b/tests/auth/oauth-routes.test.ts
@@ -171,12 +171,13 @@ describe('GET /authorize', () => {
 
     const templates = embeddedTemplateScopes(body)
     expect(Object.keys(templates)).toEqual(['read-only', 'full-access'])
-    expect(templates['read-only']).toHaveLength(193)
+    expect(templates['read-only']).toHaveLength(194)
     expect(templates['read-only']).toContain('teams-pii.read')
-    expect(templates['full-access']).toHaveLength(383)
+    expect(templates['full-access']).toHaveLength(384)
     expect(templates['full-access']).toContain('logs.write')
     expect(templates['full-access']).toContain('ssl-and-certificates.read')
-    expect(templates['full-access']).not.toContain('realtime.read')
+    expect(templates['read-only']).toContain('realtime.read')
+    expect(templates['full-access']).toContain('realtime.read')
     expect(templates['full-access']).not.toContain('realtime.realtime')
     // Happy path emits no auth_user event.
     expect(writtenEvents(metricsSpy)).not.toContain('auth_user')


### PR DESCRIPTION
## Summary

- add the newly registered `realtime.read` scope to the production consent-picker catalog
- include it in the read-only and full-access templates
- update template count assertions

The Terraform production registration landed first in `terraform-internal-oauth-clients`. The scope metadata was verified against `GET /oauth/scopes`.

## Verification

- format check passed
- lint passed
- typecheck passed
- scope-specific picker assertions compile

`npm run check` reaches the test suite, which currently has unrelated baseline failures: public-client authorization fixtures omit newly required PKCE parameters, and one modern MCP 401 test receives an empty response body.