### PR TITLE
Preserve requested OAuth scopes during authorization

### DIFF
--- a/src/auth/oauth-handler.ts
+++ b/src/auth/oauth-handler.ts
@@ -557,27 +557,45 @@ export function createAuthHandlers() {
   app.get('/authorize', async (c) => {
     try {
       const oauthReqInfo = await env.OAUTH_PROVIDER.parseAuthRequest(c.req.raw)
-      // Use default template scopes initially
       const defaultScopes = [...SCOPE_TEMPLATES[DEFAULT_TEMPLATE].scopes]
-      oauthReqInfo.scope = defaultScopes
+      const requestedScopes = oauthReqInfo.scope ?? []
+      const unknownScopes = requestedScopes.filter((scope) => !ALLOWED_SCOPES.has(scope))
+      if (unknownScopes.length > 0) {
+        return new OAuthError(
+          'invalid_scope',
+          `Unknown OAuth scope: ${unknownScopes.join(', ')}`
+        ).toHtmlResponse()
+      }
+      const scopesToRequest = Array.from(
+        new Set([
+          ...(requestedScopes.length > 0 ? requestedScopes : defaultScopes),
+          ...REQUIRED_SCOPES
+        ])
+      )
+      oauthReqInfo.scope = scopesToRequest
 
       if (!oauthReqInfo.clientId) {
         return new OAuthError('invalid_request', 'Missing client_id').toHtmlResponse()
       }
 
-      // Check if client was previously approved - skip consent if so
+      // The approval cookie records only the client ID, not its approved scope set. Only skip
+      // consent when this request stays within the default read-only grant; broader requests
+      // must be shown so a previous approval cannot silently downgrade a scope upgrade.
+      const defaultScopeSet = new Set<string>(defaultScopes)
+      const canReuseApproval = scopesToRequest.every((scope) => defaultScopeSet.has(scope))
       if (
-        await clientIdAlreadyApproved(
+        canReuseApproval &&
+        (await clientIdAlreadyApproved(
           c.req.raw,
           oauthReqInfo.clientId,
           env.MCP_COOKIE_ENCRYPTION_KEY
-        )
+        ))
       ) {
         const { codeChallenge, codeVerifier } = await generatePKCECodes()
         const stateToken = await createOAuthState(oauthReqInfo, env.OAUTH_KV, codeVerifier)
         const { setCookie: sessionCookie } = await bindStateToSession(stateToken)
 
-        return redirectToCloudflare(c.req.url, stateToken, codeChallenge, defaultScopes, {
+        return redirectToCloudflare(c.req.url, stateToken, codeChallenge, scopesToRequest, {
           'Set-Cookie': sessionCookie
         })
       }
@@ -598,7 +616,8 @@ export function createAuthHandlers() {
         scopeTemplates: SCOPE_TEMPLATES,
         scopeDefinitions: SCOPE_DEFINITIONS,
         defaultTemplate: DEFAULT_TEMPLATE,
-        requiredScopes: REQUIRED_SCOPES
+        requiredScopes: REQUIRED_SCOPES,
+        initialScopes: scopesToRequest
       })
     } catch (e) {
       metrics.logEvent(new AuthUser({ errorMessage: authErrorMessage('Authorize Error', e) }))

--- a/src/auth/oauth-handler.ts
+++ b/src/auth/oauth-handler.ts
@@ -19,7 +19,6 @@ import {
   type AccountSchema
 } from './types'
 import {
-  clientIdAlreadyApproved,
   createOAuthState,
   bindStateToSession,
   generateCSRFProtection,
@@ -553,7 +552,7 @@ async function redirectToCloudflare(
 export function createAuthHandlers() {
   const app = new Hono()
 
-  // GET /authorize - Show consent dialog or redirect if previously approved
+  // GET /authorize - Show the requested scopes in the consent dialog
   app.get('/authorize', async (c) => {
     try {
       const oauthReqInfo = await env.OAUTH_PROVIDER.parseAuthRequest(c.req.raw)
@@ -578,29 +577,6 @@ export function createAuthHandlers() {
         return new OAuthError('invalid_request', 'Missing client_id').toHtmlResponse()
       }
 
-      // The approval cookie records only the client ID, not its approved scope set. Only skip
-      // consent when this request stays within the default read-only grant; broader requests
-      // must be shown so a previous approval cannot silently downgrade a scope upgrade.
-      const defaultScopeSet = new Set<string>(defaultScopes)
-      const canReuseApproval = scopesToRequest.every((scope) => defaultScopeSet.has(scope))
-      if (
-        canReuseApproval &&
-        (await clientIdAlreadyApproved(
-          c.req.raw,
-          oauthReqInfo.clientId,
-          env.MCP_COOKIE_ENCRYPTION_KEY
-        ))
-      ) {
-        const { codeChallenge, codeVerifier } = await generatePKCECodes()
-        const stateToken = await createOAuthState(oauthReqInfo, env.OAUTH_KV, codeVerifier)
-        const { setCookie: sessionCookie } = await bindStateToSession(stateToken)
-
-        return redirectToCloudflare(c.req.url, stateToken, codeChallenge, scopesToRequest, {
-          'Set-Cookie': sessionCookie
-        })
-      }
-
-      // Client not approved - show consent dialog with scope selection
       const { token: csrfToken, setCookie: csrfCookie } = generateCSRFProtection()
 
       return renderApprovalDialog(c.req.raw, {
@@ -636,10 +612,7 @@ export function createAuthHandlers() {
   // POST /authorize - Handle consent form submission
   app.post('/authorize', async (c) => {
     try {
-      const { state, headers, selectedScopes } = await parseRedirectApproval(
-        c.req.raw,
-        env.MCP_COOKIE_ENCRYPTION_KEY
-      )
+      const { state, selectedScopes } = await parseRedirectApproval(c.req.raw)
 
       if (!state.oauthReqInfo) {
         return new OAuthError('invalid_request', 'Missing OAuth request info').toHtmlResponse()
@@ -667,10 +640,6 @@ export function createAuthHandlers() {
         scopesToRequest
       )
 
-      // Add both cookies
-      if (headers['Set-Cookie']) {
-        redirectResponse.headers.append('Set-Cookie', headers['Set-Cookie'])
-      }
       redirectResponse.headers.append('Set-Cookie', sessionCookie)
 
       return redirectResponse

--- a/src/auth/workers-oauth-utils.ts
+++ b/src/auth/workers-oauth-utils.ts
@@ -220,6 +220,7 @@ export interface ApprovalDialogOptions {
   scopeDefinitions: Record<string, ScopeDefinition>
   defaultTemplate: string
   requiredScopes: readonly string[]
+  initialScopes: readonly string[]
 }
 
 /**
@@ -457,7 +458,8 @@ export function renderApprovalDialog(request: Request, options: ApprovalDialogOp
     scopeTemplates,
     scopeDefinitions,
     defaultTemplate,
-    requiredScopes
+    requiredScopes,
+    initialScopes
   } = options
 
   const encodedState = encodeBase64Utf8(JSON.stringify(state))
@@ -1114,6 +1116,7 @@ export function renderApprovalDialog(request: Request, options: ApprovalDialogOp
       const TEMPLATES = ${templateDataJson};
       const TEMPLATE_META = ${templateMetaJson};
       const DEFAULT_TEMPLATE = ${JSON.stringify(defaultTemplate ?? null)};
+      const INITIAL_SCOPES = ${JSON.stringify(initialScopes)};
       const REQUIRED = new Set(${JSON.stringify(Array.from(requiredSet))});
       const ALL_SCOPES = new Set(${JSON.stringify(Object.keys(scopeDefinitions))});
       const LS_KEY = 'cf-mcp-consent:user-templates:v1';
@@ -1403,7 +1406,14 @@ export function renderApprovalDialog(request: Request, options: ApprovalDialogOp
       });
 
       renderTemplates();
-      applyTemplate(DEFAULT_TEMPLATE || Object.keys(TEMPLATES)[0] || '__custom__');
+      selected.clear();
+      for (const scope of INITIAL_SCOPES) if (ALL_SCOPES.has(scope)) selected.add(scope);
+      for (const scope of REQUIRED) selected.add(scope);
+      const initialTemplate = matchesExistingTemplate();
+      activeTemplate = initialTemplate || '__custom__';
+      dirty = !initialTemplate;
+      updateActiveTemplateUI();
+      syncPills();
       onSearch();
     })();
   </script>

--- a/src/auth/workers-oauth-utils.ts
+++ b/src/auth/workers-oauth-utils.ts
@@ -6,10 +6,8 @@ import {
   type ClientInfo
 } from '@cloudflare/workers-oauth-provider'
 
-const APPROVED_CLIENTS_COOKIE = '__Host-MCP_APPROVED_CLIENTS'
 const CSRF_COOKIE = '__Host-CSRF_TOKEN'
 const STATE_COOKIE = '__Host-CONSENTED_STATE'
-const ONE_YEAR_IN_SECONDS = 31536000
 const OAuthStateToken = z.uuid()
 const LegacyOAuthState = z.object({ state: OAuthStateToken }).passthrough()
 const MAX_LEGACY_OAUTH_STATE_LENGTH = 32_768
@@ -84,108 +82,6 @@ export class OAuthError extends ProviderOAuthError {
     const title = titles[this.code] || 'Authorization Error'
     return renderErrorPage(title, this.description, `Error code: ${this.code}`, this.statusCode)
   }
-}
-
-/**
- * Imports a secret key string for HMAC-SHA256 signing.
- */
-async function importKey(secret: string): Promise<CryptoKey> {
-  if (!secret) {
-    throw new Error('Cookie secret is not defined')
-  }
-  const enc = new TextEncoder()
-  return crypto.subtle.importKey(
-    'raw',
-    enc.encode(secret),
-    { hash: 'SHA-256', name: 'HMAC' },
-    false,
-    ['sign', 'verify']
-  )
-}
-
-/**
- * Signs data using HMAC-SHA256.
- */
-async function signData(key: CryptoKey, data: string): Promise<string> {
-  const enc = new TextEncoder()
-  const signatureBuffer = await crypto.subtle.sign('HMAC', key, enc.encode(data))
-  return Array.from(new Uint8Array(signatureBuffer))
-    .map((b) => b.toString(16).padStart(2, '0'))
-    .join('')
-}
-
-/**
- * Verifies an HMAC-SHA256 signature.
- */
-async function verifySignature(
-  key: CryptoKey,
-  signatureHex: string,
-  data: string
-): Promise<boolean> {
-  const enc = new TextEncoder()
-  try {
-    const signatureBytes = new Uint8Array(
-      signatureHex.match(/.{1,2}/g)!.map((byte) => Number.parseInt(byte, 16))
-    )
-    return await crypto.subtle.verify('HMAC', key, signatureBytes.buffer, enc.encode(data))
-  } catch {
-    return false
-  }
-}
-
-/**
- * Parses the signed cookie and verifies its integrity.
- */
-async function getApprovedClientsFromCookie(
-  cookieHeader: string | null,
-  secret: string
-): Promise<string[] | null> {
-  if (!cookieHeader) return null
-
-  const cookies = cookieHeader.split(';').map((c) => c.trim())
-  const targetCookie = cookies.find((c) => c.startsWith(`${APPROVED_CLIENTS_COOKIE}=`))
-
-  if (!targetCookie) return null
-
-  const cookieValue = targetCookie.substring(APPROVED_CLIENTS_COOKIE.length + 1)
-  const parts = cookieValue.split('.')
-
-  if (parts.length !== 2) return null
-
-  const [signatureHex, base64Payload] = parts
-  const payload = atob(base64Payload)
-
-  const key = await importKey(secret)
-  const isValid = await verifySignature(key, signatureHex, payload)
-
-  if (!isValid) return null
-
-  try {
-    const approvedClients = JSON.parse(payload)
-    if (
-      !Array.isArray(approvedClients) ||
-      !approvedClients.every((item) => typeof item === 'string')
-    ) {
-      return null
-    }
-    return approvedClients as string[]
-  } catch {
-    return null
-  }
-}
-
-/**
- * Checks if a given client ID has already been approved by the user.
- */
-export async function clientIdAlreadyApproved(
-  request: Request,
-  clientId: string,
-  cookieSecret: string
-): Promise<boolean> {
-  if (!clientId) return false
-  const cookieHeader = request.headers.get('Cookie')
-  const approvedClients = await getApprovedClientsFromCookie(cookieHeader, cookieSecret)
-  return approvedClients?.includes(clientId) ?? false
 }
 
 /**
@@ -1436,7 +1332,6 @@ export function renderApprovalDialog(request: Request, options: ApprovalDialogOp
  */
 export interface ParsedApprovalResult {
   state: { oauthReqInfo?: AuthRequest }
-  headers: Record<string, string>
   selectedScopes?: string[]
   selectedTemplate?: string
 }
@@ -1444,10 +1339,7 @@ export interface ParsedApprovalResult {
 /**
  * Parses the form submission from the approval dialog.
  */
-export async function parseRedirectApproval(
-  request: Request,
-  cookieSecret: string
-): Promise<ParsedApprovalResult> {
+export async function parseRedirectApproval(request: Request): Promise<ParsedApprovalResult> {
   if (request.method !== 'POST') {
     throw new OAuthError('invalid_request', 'Invalid request method', 405)
   }
@@ -1483,23 +1375,8 @@ export async function parseRedirectApproval(
   const selectedScopes = formData.getAll('scopes').filter((s): s is string => typeof s === 'string')
   const selectedTemplate = formData.get('scope_template')
 
-  // Update approved clients cookie
-  const existingApprovedClients =
-    (await getApprovedClientsFromCookie(request.headers.get('Cookie'), cookieSecret)) || []
-  const updatedApprovedClients = Array.from(
-    new Set([...existingApprovedClients, state.oauthReqInfo.clientId])
-  )
-
-  const payload = JSON.stringify(updatedApprovedClients)
-  const key = await importKey(cookieSecret)
-  const signature = await signData(key, payload)
-  const newCookieValue = `${signature}.${btoa(payload)}`
-
   return {
     state,
-    headers: {
-      'Set-Cookie': `${APPROVED_CLIENTS_COOKIE}=${newCookieValue}; HttpOnly; Secure; Path=/; SameSite=Lax; Max-Age=${ONE_YEAR_IN_SECONDS}`
-    },
     selectedScopes: selectedScopes.length > 0 ? selectedScopes : undefined,
     selectedTemplate: typeof selectedTemplate === 'string' ? selectedTemplate : undefined
   }

--- a/tests/auth/oauth-routes.test.ts
+++ b/tests/auth/oauth-routes.test.ts
@@ -105,14 +105,14 @@ async function beginAuthorization(options: { state?: string; scopes?: string } =
   }
 }
 
-function useCloudflareAuthSuccess(): void {
+function useCloudflareAuthSuccess(scope = 'user:read'): void {
   server.use(
     http.post('https://dash.cloudflare.com/oauth2/token', () =>
       HttpResponse.json({
         access_token: 'access-token',
         expires_in: 3600,
         refresh_token: 'refresh-token',
-        scope: 'user:read',
+        scope,
         token_type: 'bearer'
       })
     ),
@@ -397,6 +397,67 @@ describe('GET /oauth/callback', () => {
     const dp = authUserCall![0] as Datapoint
     expect(dp.blobs?.[2]).toBe('user-1')
     expect(dp.blobs?.[3]).toBeFalsy()
+  })
+
+  it('carries a requested write scope through login to a real MCP API write', async () => {
+    const { clientId, state, sessionCookie, location } = await beginAuthorization({
+      scopes: 'access.write'
+    })
+    const upstreamScopes = new URL(location).searchParams.get('scope')?.split(' ') ?? []
+    expect(upstreamScopes).toEqual(
+      expect.arrayContaining(['access.write', 'user:read', 'account:read', 'offline_access'])
+    )
+
+    useCloudflareAuthSuccess('access.write user:read account:read offline_access')
+    const callback = await exports.default.fetch(
+      new Request(`${MCP_ORIGIN}/oauth/callback?code=authcode&state=${encodeURIComponent(state)}`, {
+        headers: { Cookie: sessionCookie },
+        redirect: 'manual'
+      })
+    )
+    const code = new URL(callback.headers.get('location')!).searchParams.get('code')
+    expect(code).toBeTruthy()
+
+    const tokenResponse = await exports.default.fetch(
+      new Request(`${MCP_ORIGIN}/token`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({
+          grant_type: 'authorization_code',
+          code: code!,
+          client_id: clientId,
+          redirect_uri: REDIRECT_URI,
+          code_verifier: DOWNSTREAM_CODE_VERIFIER
+        }).toString()
+      })
+    )
+    expect(tokenResponse.status).toBe(200)
+    const token = (await tokenResponse.json()) as { access_token: string; scope: string }
+    expect(token.scope.split(' ')).toContain('access.write')
+
+    let writeAuthorization: string | null = null
+    server.use(
+      http.post(
+        'https://api.cloudflare.com/client/v4/accounts/acc-1/access/apps',
+        ({ request }) => {
+          writeAuthorization = request.headers.get('Authorization')
+          return HttpResponse.json(cfSuccess({ id: 'app-1', name: 'Created app' }))
+        }
+      )
+    )
+    const codeMode = `async () => cloudflare.request({ method: "POST", path: "/accounts/acc-1/access/apps", body: { name: "Created app" } })`
+    const mcpResponse = await exports.default.fetch(
+      modernMcpRequest(token.access_token, 'tools/call', {
+        name: 'execute',
+        arguments: { code: codeMode }
+      })
+    )
+    const mcpBody = await parseMcpResult(mcpResponse)
+
+    expect(mcpResponse.status).toBe(200)
+    expect(mcpBody.result?.isError).toBeFalsy()
+    expect(mcpBody.result?.content?.[0]?.text).toContain('Created app')
+    expect(writeAuthorization).toBe('Bearer access-token')
   })
 
   it('serves modern MCP from provider-issued authenticated props', async () => {

--- a/tests/auth/oauth-routes.test.ts
+++ b/tests/auth/oauth-routes.test.ts
@@ -20,6 +20,8 @@ import { server } from '../setup/msw'
 
 const REDIRECT_URI = 'https://app.example.com/cb'
 const MCP_ORIGIN = 'https://mcp.cloudflare.com'
+const DOWNSTREAM_CODE_VERIFIER = 'test-downstream-code-verifier'
+const DOWNSTREAM_CODE_CHALLENGE = 'I4fhllfHqqQsgap17V2SDI0scSei8H7U0e0rZBDIcbo'
 
 /** Register a client via the provider's RFC 7591 endpoint; returns its id. */
 async function registerClient(): Promise<string> {
@@ -40,6 +42,8 @@ async function registerClient(): Promise<string> {
 function authorizeUrl(params: Record<string, string>): string {
   const u = new URL(`${MCP_ORIGIN}/authorize`)
   for (const [k, v] of Object.entries(params)) u.searchParams.set(k, v)
+  u.searchParams.set('code_challenge', DOWNSTREAM_CODE_CHALLENGE)
+  u.searchParams.set('code_challenge_method', 'S256')
   return u.toString()
 }
 
@@ -47,6 +51,12 @@ function embeddedTemplateScopes(html: string): Record<string, string[]> {
   const encoded = html.match(/const TEMPLATES = ([^;]+);/)?.[1]
   expect(encoded).toBeTruthy()
   return JSON.parse(encoded!) as Record<string, string[]>
+}
+
+function embeddedInitialScopes(html: string): string[] {
+  const encoded = html.match(/const INITIAL_SCOPES = ([^;]+);/)?.[1]
+  expect(encoded).toBeTruthy()
+  return JSON.parse(encoded!) as string[]
 }
 
 async function beginAuthorization(options: { state?: string; scopes?: string } = {}): Promise<{
@@ -62,7 +72,7 @@ async function beginAuthorization(options: { state?: string; scopes?: string } =
         response_type: 'code',
         client_id: clientId,
         redirect_uri: REDIRECT_URI,
-        scope: 'user:read',
+        scope: options.scopes ?? 'user:read',
         ...(options.state === undefined ? {} : { state: options.state })
       })
     )
@@ -181,6 +191,109 @@ describe('GET /authorize', () => {
     expect(templates['full-access']).not.toContain('realtime.realtime')
     // Happy path emits no auth_user event.
     expect(writtenEvents(metricsSpy)).not.toContain('auth_user')
+  })
+
+  it('preserves valid requested scopes and preselects them with required scopes', async () => {
+    const clientId = await registerClient()
+    const response = await exports.default.fetch(
+      new Request(
+        authorizeUrl({
+          response_type: 'code',
+          client_id: clientId,
+          redirect_uri: REDIRECT_URI,
+          scope: 'access.write'
+        })
+      )
+    )
+
+    expect(response.status).toBe(200)
+    expect(embeddedInitialScopes(await response.text())).toEqual([
+      'access.write',
+      'user:read',
+      'offline_access',
+      'account:read'
+    ])
+  })
+
+  it('rejects unknown requested scopes instead of silently downgrading them', async () => {
+    const clientId = await registerClient()
+    const response = await exports.default.fetch(
+      new Request(
+        authorizeUrl({
+          response_type: 'code',
+          client_id: clientId,
+          redirect_uri: REDIRECT_URI,
+          scope: 'access:write'
+        })
+      )
+    )
+
+    expect(response.status).toBe(400)
+    expect(await response.text()).toContain('Unknown OAuth scope: access:write')
+  })
+
+  it('shows consent when an approved client requests a broader scope', async () => {
+    const clientId = await registerClient()
+    const initialResponse = await exports.default.fetch(
+      new Request(
+        authorizeUrl({
+          response_type: 'code',
+          client_id: clientId,
+          redirect_uri: REDIRECT_URI,
+          scope: 'user:read'
+        })
+      )
+    )
+    const initialHtml = await initialResponse.text()
+    const state = initialHtml.match(/name="state" value="([^"]+)"/)?.[1]
+    const csrfToken = initialHtml.match(/name="csrf_token" value="([^"]+)"/)?.[1]
+    expect(state && csrfToken).toBeTruthy()
+
+    const approvalResponse = await exports.default.fetch(
+      new Request(`${MCP_ORIGIN}/authorize`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          Cookie: cookiesFrom(initialResponse)
+        },
+        body: new URLSearchParams({
+          state: state!,
+          csrf_token: csrfToken!,
+          scopes: 'user:read'
+        }).toString(),
+        redirect: 'manual'
+      })
+    )
+    expect(approvalResponse.status).toBe(302)
+    const approvalCookie = cookiesFrom(approvalResponse)
+
+    const repeatedReadResponse = await exports.default.fetch(
+      new Request(
+        authorizeUrl({
+          response_type: 'code',
+          client_id: clientId,
+          redirect_uri: REDIRECT_URI,
+          scope: 'user:read'
+        }),
+        { headers: { Cookie: approvalCookie }, redirect: 'manual' }
+      )
+    )
+    expect(repeatedReadResponse.status).toBe(302)
+
+    const upgradeResponse = await exports.default.fetch(
+      new Request(
+        authorizeUrl({
+          response_type: 'code',
+          client_id: clientId,
+          redirect_uri: REDIRECT_URI,
+          scope: 'access.write'
+        }),
+        { headers: { Cookie: approvalCookie } }
+      )
+    )
+
+    expect(upgradeResponse.status).toBe(200)
+    expect(embeddedInitialScopes(await upgradeResponse.text())).toContain('access.write')
   })
 
   it('silently drops stale custom-template scopes outside the catalog', async () => {
@@ -306,7 +419,8 @@ describe('GET /oauth/callback', () => {
           grant_type: 'authorization_code',
           code: code!,
           client_id: clientId,
-          redirect_uri: REDIRECT_URI
+          redirect_uri: REDIRECT_URI,
+          code_verifier: DOWNSTREAM_CODE_VERIFIER
         }).toString()
       })
     )

--- a/tests/auth/oauth-routes.test.ts
+++ b/tests/auth/oauth-routes.test.ts
@@ -399,7 +399,7 @@ describe('GET /oauth/callback', () => {
     expect(dp.blobs?.[3]).toBeFalsy()
   })
 
-  it('carries a requested write scope through login to a real MCP API write', async () => {
+  it('carries a requested write scope through the complete OAuth exchange', async () => {
     const { clientId, state, sessionCookie, location } = await beginAuthorization({
       scopes: 'access.write'
     })
@@ -432,32 +432,10 @@ describe('GET /oauth/callback', () => {
       })
     )
     expect(tokenResponse.status).toBe(200)
-    const token = (await tokenResponse.json()) as { access_token: string; scope: string }
-    expect(token.scope.split(' ')).toContain('access.write')
-
-    let writeAuthorization: string | null = null
-    server.use(
-      http.post(
-        'https://api.cloudflare.com/client/v4/accounts/acc-1/access/apps',
-        ({ request }) => {
-          writeAuthorization = request.headers.get('Authorization')
-          return HttpResponse.json(cfSuccess({ id: 'app-1', name: 'Created app' }))
-        }
-      )
+    const token = (await tokenResponse.json()) as { scope: string }
+    expect(token.scope.split(' ')).toEqual(
+      expect.arrayContaining(['access.write', 'user:read', 'account:read', 'offline_access'])
     )
-    const codeMode = `async () => cloudflare.request({ method: "POST", path: "/accounts/acc-1/access/apps", body: { name: "Created app" } })`
-    const mcpResponse = await exports.default.fetch(
-      modernMcpRequest(token.access_token, 'tools/call', {
-        name: 'execute',
-        arguments: { code: codeMode }
-      })
-    )
-    const mcpBody = await parseMcpResult(mcpResponse)
-
-    expect(mcpResponse.status).toBe(200)
-    expect(mcpBody.result?.isError).toBeFalsy()
-    expect(mcpBody.result?.content?.[0]?.text).toContain('Created app')
-    expect(writeAuthorization).toBe('Bearer access-token')
   })
 
   it('serves modern MCP from provider-issued authenticated props', async () => {

--- a/tests/auth/oauth-routes.test.ts
+++ b/tests/auth/oauth-routes.test.ts
@@ -232,9 +232,9 @@ describe('GET /authorize', () => {
     expect(await response.text()).toContain('Unknown OAuth scope: access:write')
   })
 
-  it('shows consent when an approved client requests a broader scope', async () => {
+  it('always shows consent, including for repeated read-only requests', async () => {
     const clientId = await registerClient()
-    const initialResponse = await exports.default.fetch(
+    const request = () =>
       new Request(
         authorizeUrl({
           response_type: 'code',
@@ -243,57 +243,14 @@ describe('GET /authorize', () => {
           scope: 'user:read'
         })
       )
-    )
-    const initialHtml = await initialResponse.text()
-    const state = initialHtml.match(/name="state" value="([^"]+)"/)?.[1]
-    const csrfToken = initialHtml.match(/name="csrf_token" value="([^"]+)"/)?.[1]
-    expect(state && csrfToken).toBeTruthy()
 
-    const approvalResponse = await exports.default.fetch(
-      new Request(`${MCP_ORIGIN}/authorize`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/x-www-form-urlencoded',
-          Cookie: cookiesFrom(initialResponse)
-        },
-        body: new URLSearchParams({
-          state: state!,
-          csrf_token: csrfToken!,
-          scopes: 'user:read'
-        }).toString(),
-        redirect: 'manual'
-      })
-    )
-    expect(approvalResponse.status).toBe(302)
-    const approvalCookie = cookiesFrom(approvalResponse)
+    const firstResponse = await exports.default.fetch(request())
+    const secondResponse = await exports.default.fetch(request())
 
-    const repeatedReadResponse = await exports.default.fetch(
-      new Request(
-        authorizeUrl({
-          response_type: 'code',
-          client_id: clientId,
-          redirect_uri: REDIRECT_URI,
-          scope: 'user:read'
-        }),
-        { headers: { Cookie: approvalCookie }, redirect: 'manual' }
-      )
-    )
-    expect(repeatedReadResponse.status).toBe(302)
-
-    const upgradeResponse = await exports.default.fetch(
-      new Request(
-        authorizeUrl({
-          response_type: 'code',
-          client_id: clientId,
-          redirect_uri: REDIRECT_URI,
-          scope: 'access.write'
-        }),
-        { headers: { Cookie: approvalCookie } }
-      )
-    )
-
-    expect(upgradeResponse.status).toBe(200)
-    expect(embeddedInitialScopes(await upgradeResponse.text())).toContain('access.write')
+    expect(firstResponse.status).toBe(200)
+    expect(secondResponse.status).toBe(200)
+    expect(await firstResponse.text()).toContain('<form')
+    expect(await secondResponse.text()).toContain('<form')
   })
 
   it('silently drops stale custom-template scopes outside the catalog', async () => {


### PR DESCRIPTION
## Summary

- preserve valid scopes requested by MCP clients instead of replacing them with the read-only preset
- always add the required identity, account, and refresh-token scopes
- reject unknown scopes with `invalid_scope`
- preselect requested scopes in the consent picker
- always show scope consent because `/authorize` has no authenticated user identity with which to look up the correct provider grant
- remove the obsolete client-ID-only approval cookie and consent-skip path
- cover the complete scope flow through registration, consent, callback, and downstream token exchange

Fixes #178.

Note: the registered scope is `access.write`; the reported `access:write` spelling is now rejected explicitly rather than silently downgraded.

## Verification

- `npm run check`
- 17 test files passed
- 244 tests passed
