### PR TITLE
chore: upgrade Workers OAuth provider to 0.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "cloudflare-mcp",
       "version": "0.1.0",
       "dependencies": {
-        "@cloudflare/workers-oauth-provider": "^0.8.3",
+        "@cloudflare/workers-oauth-provider": "^0.9.0",
         "@modelcontextprotocol/server": "2.0.0",
         "hono": "^4.12.25",
         "zod": "^4.3.5"
@@ -167,9 +167,9 @@
       }
     },
     "node_modules/@cloudflare/workers-oauth-provider": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-oauth-provider/-/workers-oauth-provider-0.8.3.tgz",
-      "integrity": "sha512-5dIeQlJTDKAQvy3GcrtWBhPvTb9lHeRp/m8MoostTkcrbrGImH8zKSdJhogQ5YSTFUCg+b7FBg38b7KCM/x3VQ==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-oauth-provider/-/workers-oauth-provider-0.9.0.tgz",
+      "integrity": "sha512-ulg0ixJ/5TCLypQVLeFAeQ9y/oz0Qju9k3uAMYtEYz1CXcyoxIUirkWz+exjv8LTsmJ5f+ethIKQeyJmZdqdBg==",
       "license": "MIT"
     },
     "node_modules/@cspotcode/source-map-support": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "seed:prod": "tsx scripts/seed-r2.ts production"
   },
   "dependencies": {
-    "@cloudflare/workers-oauth-provider": "^0.8.3",
+    "@cloudflare/workers-oauth-provider": "^0.9.0",
     "@modelcontextprotocol/server": "2.0.0",
     "hono": "^4.12.25",
     "zod": "^4.3.5"


### PR DESCRIPTION
## Summary

- upgrade `@cloudflare/workers-oauth-provider` from `^0.8.3` to `^0.9.0`
- refresh the npm lockfile against the published `0.9.0` package

## Validation

- `npm ci`
- `npm run check` (244 tests)
- `npm ls @cloudflare/workers-oauth-provider`
- `git diff --check`
