### PR TITLE
fix(mcp): disable unsupported subscription streams

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,7 +113,7 @@ The core innovation: instead of 2,500 MCP tools (~244K tokens), two tools handle
 - `src/mcp-handler.ts` uses `createMcpHandler(factory)` directly from `@modelcontextprotocol/server`; this repository does not depend on the Agents SDK.
 - Each authenticated request creates an upstream handler whose factory closes over validated `AuthProps`, matching the repository's pre-migration explicit data flow.
 - The handler serves MCP `2026-07-28` and keeps the upstream default stateless 2025 compatibility path. Its factory creates a fresh `McpServer` for every request.
-- No MCP session ID, protocol transport state, replay store, Durable Object, or Node async-context bridge is used.
+- No MCP session ID, protocol transport state, replay store, Durable Object, or Node async-context bridge is used. The handler sets the SDK's `maxSubscriptions: 0` because this server publishes no change notifications; `subscriptions/listen` is rejected immediately instead of opening a long-lived SSE stream.
 - Deployment-static Host and browser Origin allowlists cover localhost, staging, and production. Do not derive either trust list from the incoming request URL or headers.
 
 ### Worker Loader API

--- a/src/mcp-handler.ts
+++ b/src/mcp-handler.ts
@@ -23,14 +23,20 @@ const ALLOWED_MCP_ORIGIN_HOSTNAMES = [
 ]
 
 function createAuthenticatedHandler(props: AuthProps) {
-  return createMcpHandler(({ requestInfo }) => {
-    if (!requestInfo) {
-      throw new Error('The Cloudflare MCP server requires an HTTP request')
-    }
+  return createMcpHandler(
+    ({ requestInfo }) => {
+      if (!requestInfo) {
+        throw new Error('The Cloudflare MCP server requires an HTTP request')
+      }
 
-    const codemode = new URL(requestInfo.url).searchParams.get('codemode') !== 'false'
-    return createServer(props, codemode)
-  })
+      const codemode = new URL(requestInfo.url).searchParams.get('codemode') !== 'false'
+      return createServer(props, codemode)
+    },
+    // This server publishes no change notifications and intentionally keeps no
+    // long-lived request state. Reject subscriptions/listen before the SDK opens
+    // an SSE stream and pins an isolate.
+    { maxSubscriptions: 0 }
+  )
 }
 
 // Handler options are intentionally omitted. The SDK defaults to:

--- a/tests/mcp-modern.test.ts
+++ b/tests/mcp-modern.test.ts
@@ -64,6 +64,22 @@ describe('MCP 2026-07-28 stateless handler', () => {
     expect(body.result).not.toHaveProperty('serverInfo')
   })
 
+  it('rejects subscriptions instead of opening a long-lived stream', async () => {
+    const response = await exports.default.fetch(
+      modernMcpRequest(API_TOKEN, 'subscriptions/listen', {
+        notifications: { toolsListChanged: true }
+      })
+    )
+    const body = await parseMcpResult(response)
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toContain('application/json')
+    expect(response.headers.get('content-type')).not.toContain('text/event-stream')
+    expect(body).toMatchObject({
+      error: { code: -32603, message: 'Subscription limit reached' }
+    })
+  })
+
   it('serves modern tools/list with a complete result', async () => {
     const response = await exports.default.fetch(modernMcpRequest(API_TOKEN, 'tools/list'))
     const body = await parseMcpResult(response)


### PR DESCRIPTION
## Summary

Disable `subscriptions/listen` using the TypeScript SDK's canonical `createMcpHandler` option:

```ts
{ maxSubscriptions: 0 }
```

This server publishes no tool, prompt, or resource change notifications and intentionally keeps no long-lived request state. The SDK otherwise opens an SSE stream backed by its in-memory event bus even when the honored notification filter is empty.

## Production evidence

Workers Observability recorded two `exceededMemory` outcomes after the previous deployment. Both were authenticated `subscriptions/listen` requests from `opencode/1.18.8` that remained open for 30–51 minutes. No tool call or refresh request was involved.

With `maxSubscriptions: 0`, the SDK immediately returns an in-band JSON-RPC error instead of creating a listener or SSE stream:

```json
{
  "error": {
    "code": -32603,
    "message": "Subscription limit reached"
  }
}
```

## Validation

- `npm run check`: 19 files, 248 tests
- deployed to staging as `e87f93b0-5845-4245-b167-2db3e58406f2`
- authenticated live `subscriptions/listen`: HTTP 200 JSON, `-32603`, no SSE stream
