### PR TITLE
fix(auth): return spec-correct authorization errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "cloudflare-mcp",
       "version": "0.1.0",
       "dependencies": {
-        "@cloudflare/workers-oauth-provider": "https://pkg.pr.new/cloudflare/workers-oauth-provider/@cloudflare/workers-oauth-provider@283",
+        "@cloudflare/workers-oauth-provider": "0.10.0",
         "@modelcontextprotocol/server": "2.0.0",
         "hono": "^4.12.25",
         "zod": "^4.3.5"
@@ -167,9 +167,9 @@
       }
     },
     "node_modules/@cloudflare/workers-oauth-provider": {
-      "version": "0.9.1",
-      "resolved": "https://pkg.pr.new/cloudflare/workers-oauth-provider/@cloudflare/workers-oauth-provider@283",
-      "integrity": "sha512-7sGQSVGVShVL4jPcHU3pj66EYlaJIiQG7fYkKTQ+G5us9BToj109+UJcS3k/qNEUSngqZTRWnf7ZRmIHoaPpvw==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-oauth-provider/-/workers-oauth-provider-0.10.0.tgz",
+      "integrity": "sha512-hH9AHhhQ47z9u5enEnWkYb1CucKNWRdE9NdCHpbiWTy7U0LrkaSCb13cefKqhVz1hEVji38/eCA/H+bNxgTvAQ==",
       "license": "MIT"
     },
     "node_modules/@cspotcode/source-map-support": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "cloudflare-mcp",
       "version": "0.1.0",
       "dependencies": {
-        "@cloudflare/workers-oauth-provider": "^0.9.1",
+        "@cloudflare/workers-oauth-provider": "https://pkg.pr.new/cloudflare/workers-oauth-provider/@cloudflare/workers-oauth-provider@283",
         "@modelcontextprotocol/server": "2.0.0",
         "hono": "^4.12.25",
         "zod": "^4.3.5"
@@ -168,8 +168,8 @@
     },
     "node_modules/@cloudflare/workers-oauth-provider": {
       "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-oauth-provider/-/workers-oauth-provider-0.9.1.tgz",
-      "integrity": "sha512-ELfEDzACNRvgvHij6f9m2rLPj7S6M1dJ1iLNXcQA15TD35wBYoQjmxUJqyZsyf19mbAqUav9B+hgOPqYpG3CHw==",
+      "resolved": "https://pkg.pr.new/cloudflare/workers-oauth-provider/@cloudflare/workers-oauth-provider@283",
+      "integrity": "sha512-7sGQSVGVShVL4jPcHU3pj66EYlaJIiQG7fYkKTQ+G5us9BToj109+UJcS3k/qNEUSngqZTRWnf7ZRmIHoaPpvw==",
       "license": "MIT"
     },
     "node_modules/@cspotcode/source-map-support": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "seed:prod": "tsx scripts/seed-r2.ts production"
   },
   "dependencies": {
-    "@cloudflare/workers-oauth-provider": "https://pkg.pr.new/cloudflare/workers-oauth-provider/@cloudflare/workers-oauth-provider@283",
+    "@cloudflare/workers-oauth-provider": "0.10.0",
     "@modelcontextprotocol/server": "2.0.0",
     "hono": "^4.12.25",
     "zod": "^4.3.5"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "seed:prod": "tsx scripts/seed-r2.ts production"
   },
   "dependencies": {
-    "@cloudflare/workers-oauth-provider": "^0.9.1",
+    "@cloudflare/workers-oauth-provider": "https://pkg.pr.new/cloudflare/workers-oauth-provider/@cloudflare/workers-oauth-provider@283",
     "@modelcontextprotocol/server": "2.0.0",
     "hono": "^4.12.25",
     "zod": "^4.3.5"

--- a/src/auth/oauth-handler.ts
+++ b/src/auth/oauth-handler.ts
@@ -25,9 +25,9 @@ import { MetricsTracker, AuthUser } from '../metrics'
 import { SERVER_INFO } from '../constants'
 
 import {
+  AuthorizationError,
   CimdFetchError,
   type AuthRequest,
-  type ClientInfo,
   type OAuthHelpers,
   type TokenExchangeCallbackOptions,
   type TokenExchangeCallbackResult
@@ -150,19 +150,24 @@ export function createAuthHandlers() {
   // GET /authorize - Show the requested scopes in the consent dialog
   app.get('/authorize', async (c) => {
     try {
-      const requestedClientId = new URL(c.req.url).searchParams.get('client_id')
-      if (!requestedClientId) {
-        return new OAuthError('invalid_request', 'Missing client_id').toHtmlResponse()
-      }
-
-      // Unknown clients cannot be redirected safely because their redirect URI
-      // has not been validated. Classify definitive absence before the provider's
-      // parseAuthRequest(), which currently throws a plain Error for this case.
-      // Lookup failures still throw and remain visible as server errors.
-      let client: ClientInfo | null
+      let oauthReqInfo: AuthRequest
       try {
-        client = await env.OAUTH_PROVIDER.lookupClient(requestedClientId)
+        oauthReqInfo = await env.OAUTH_PROVIDER.parseAuthRequest(c.req.raw)
       } catch (error) {
+        if (error instanceof AuthorizationError) {
+          if (!error.redirectUri) {
+            return new OAuthError(error.code, error.description).toHtmlResponse()
+          }
+          const redirect = new URL(error.redirectUri)
+          redirect.searchParams.set('error', error.code)
+          redirect.searchParams.set('error_description', error.description)
+          if (error.state) redirect.searchParams.set('state', error.state)
+          if (error.issuer) redirect.searchParams.set('iss', error.issuer)
+          return new Response(null, {
+            status: 302,
+            headers: { Location: redirect.href, 'Cache-Control': 'no-store' }
+          })
+        }
         if (error instanceof CimdFetchError) {
           return new OAuthError(
             'temporarily_unavailable',
@@ -173,11 +178,6 @@ export function createAuthHandlers() {
         }
         throw error
       }
-      if (!client) {
-        return new OAuthError('invalid_request', 'Invalid client_id').toHtmlResponse()
-      }
-
-      const oauthReqInfo = await env.OAUTH_PROVIDER.parseAuthRequest(c.req.raw)
       const defaultScopes = [...SCOPE_TEMPLATES[DEFAULT_TEMPLATE].scopes]
       const requestedScopes = oauthReqInfo.scope ?? []
       const unknownScopes = requestedScopes.filter((scope) => !ALLOWED_SCOPES.has(scope))
@@ -198,7 +198,7 @@ export function createAuthHandlers() {
       const { token: csrfToken, setCookie: csrfCookie } = generateCSRFProtection()
 
       return renderApprovalDialog(c.req.raw, {
-        client,
+        client: await env.OAUTH_PROVIDER.lookupClient(oauthReqInfo.clientId),
         server: {
           name: 'Cloudflare API MCP',
           logo: 'https://www.cloudflare.com/favicon.ico',

--- a/src/auth/oauth-handler.ts
+++ b/src/auth/oauth-handler.ts
@@ -24,11 +24,13 @@ import { withRefreshAdmission } from './refresh-admission-gate'
 import { MetricsTracker, AuthUser } from '../metrics'
 import { SERVER_INFO } from '../constants'
 
-import type {
-  AuthRequest,
-  OAuthHelpers,
-  TokenExchangeCallbackOptions,
-  TokenExchangeCallbackResult
+import {
+  CimdFetchError,
+  type AuthRequest,
+  type ClientInfo,
+  type OAuthHelpers,
+  type TokenExchangeCallbackOptions,
+  type TokenExchangeCallbackResult
 } from '@cloudflare/workers-oauth-provider'
 
 interface AuthEnv extends Env {
@@ -148,6 +150,33 @@ export function createAuthHandlers() {
   // GET /authorize - Show the requested scopes in the consent dialog
   app.get('/authorize', async (c) => {
     try {
+      const requestedClientId = new URL(c.req.url).searchParams.get('client_id')
+      if (!requestedClientId) {
+        return new OAuthError('invalid_request', 'Missing client_id').toHtmlResponse()
+      }
+
+      // Unknown clients cannot be redirected safely because their redirect URI
+      // has not been validated. Classify definitive absence before the provider's
+      // parseAuthRequest(), which currently throws a plain Error for this case.
+      // Lookup failures still throw and remain visible as server errors.
+      let client: ClientInfo | null
+      try {
+        client = await env.OAUTH_PROVIDER.lookupClient(requestedClientId)
+      } catch (error) {
+        if (error instanceof CimdFetchError) {
+          return new OAuthError(
+            'temporarily_unavailable',
+            'Client metadata is temporarily unavailable. Please try again.',
+            503,
+            { 'Retry-After': '30' }
+          ).toHtmlResponse()
+        }
+        throw error
+      }
+      if (!client) {
+        return new OAuthError('invalid_request', 'Invalid client_id').toHtmlResponse()
+      }
+
       const oauthReqInfo = await env.OAUTH_PROVIDER.parseAuthRequest(c.req.raw)
       const defaultScopes = [...SCOPE_TEMPLATES[DEFAULT_TEMPLATE].scopes]
       const requestedScopes = oauthReqInfo.scope ?? []
@@ -166,14 +195,10 @@ export function createAuthHandlers() {
       )
       oauthReqInfo.scope = scopesToRequest
 
-      if (!oauthReqInfo.clientId) {
-        return new OAuthError('invalid_request', 'Missing client_id').toHtmlResponse()
-      }
-
       const { token: csrfToken, setCookie: csrfCookie } = generateCSRFProtection()
 
       return renderApprovalDialog(c.req.raw, {
-        client: await env.OAUTH_PROVIDER.lookupClient(oauthReqInfo.clientId),
+        client,
         server: {
           name: 'Cloudflare API MCP',
           logo: 'https://www.cloudflare.com/favicon.ico',

--- a/src/auth/workers-oauth-utils.ts
+++ b/src/auth/workers-oauth-utils.ts
@@ -80,7 +80,15 @@ export class OAuthError extends ProviderOAuthError {
       temporarily_unavailable: 'Temporarily Unavailable'
     }
     const title = titles[this.code] || 'Authorization Error'
-    return renderErrorPage(title, this.description, `Error code: ${this.code}`, this.statusCode)
+    const response = renderErrorPage(
+      title,
+      this.description,
+      `Error code: ${this.code}`,
+      this.statusCode
+    )
+    const headers = new Headers(response.headers)
+    for (const [name, value] of Object.entries(this.headers ?? {})) headers.set(name, value)
+    return new Response(response.body, { status: response.status, headers })
   }
 }
 

--- a/tests/auth/oauth-routes.test.ts
+++ b/tests/auth/oauth-routes.test.ts
@@ -311,6 +311,69 @@ describe('GET /authorize', () => {
     expect(forwardedScopes).not.toContain('removed-from-catalog.read')
   })
 
+  it('does not redirect a known client with an invalid redirect URI', async () => {
+    const clientId = await registerClient()
+    const response = await exports.default.fetch(
+      new Request(
+        authorizeUrl({
+          response_type: 'code',
+          client_id: clientId,
+          redirect_uri: 'https://attacker.example/callback',
+          code_challenge: DOWNSTREAM_CODE_CHALLENGE,
+          code_challenge_method: 'S256'
+        })
+      ),
+      { redirect: 'manual' }
+    )
+
+    expect(response.status).toBe(400)
+    expect(response.headers.get('location')).toBeNull()
+    expect(await response.text()).toContain('Invalid redirect URI')
+  })
+
+  it('redirects a known client PKCE error with state and issuer', async () => {
+    const clientId = await registerClient()
+    const url = new URL(`${MCP_ORIGIN}/authorize`)
+    url.search = new URLSearchParams({
+      response_type: 'code',
+      client_id: clientId,
+      redirect_uri: REDIRECT_URI,
+      state: 'client-state'
+    }).toString()
+    const response = await exports.default.fetch(new Request(url), { redirect: 'manual' })
+
+    expect(response.status).toBe(302)
+    const redirect = new URL(response.headers.get('location')!)
+    expect(redirect.origin + redirect.pathname).toBe(REDIRECT_URI)
+    expect(redirect.searchParams.get('error')).toBe('invalid_request')
+    expect(redirect.searchParams.get('state')).toBe('client-state')
+    expect(redirect.searchParams.get('iss')).toBe(MCP_ORIGIN)
+    expect(response.headers.get('cache-control')).toBe('no-store')
+  })
+
+  it('redirects an unsupported response type with the correct OAuth code', async () => {
+    const clientId = await registerClient()
+    const response = await exports.default.fetch(
+      new Request(
+        authorizeUrl({
+          response_type: 'unsupported',
+          client_id: clientId,
+          redirect_uri: REDIRECT_URI,
+          state: 'client-state',
+          code_challenge: DOWNSTREAM_CODE_CHALLENGE,
+          code_challenge_method: 'S256'
+        })
+      ),
+      { redirect: 'manual' }
+    )
+
+    expect(response.status).toBe(302)
+    const redirect = new URL(response.headers.get('location')!)
+    expect(redirect.searchParams.get('error')).toBe('unsupported_response_type')
+    expect(redirect.searchParams.get('state')).toBe('client-state')
+    expect(redirect.searchParams.get('iss')).toBe(MCP_ORIGIN)
+  })
+
   it('returns a local invalid_request page for an unknown client', async () => {
     const res = await exports.default.fetch(
       new Request(
@@ -368,7 +431,7 @@ describe('GET /authorize', () => {
     )
 
     expect(response.status).toBe(400)
-    expect(await response.text()).toContain('Missing client_id')
+    expect(await response.text()).toContain('client_id is required')
     expect(writtenEvents(metricsSpy)).not.toContain('auth_user')
   })
 })

--- a/tests/auth/oauth-routes.test.ts
+++ b/tests/auth/oauth-routes.test.ts
@@ -1,3 +1,4 @@
+import { CimdFetchError, type OAuthHelpers } from '@cloudflare/workers-oauth-provider'
 import { env, exports } from 'cloudflare:workers'
 import { http, HttpResponse } from 'msw'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -310,7 +311,7 @@ describe('GET /authorize', () => {
     expect(forwardedScopes).not.toContain('removed-from-catalog.read')
   })
 
-  it('logs an auth_user error and 500s for an unknown client', async () => {
+  it('returns a local invalid_request page for an unknown client', async () => {
     const res = await exports.default.fetch(
       new Request(
         authorizeUrl({
@@ -323,10 +324,52 @@ describe('GET /authorize', () => {
       )
     )
 
-    // OAuthProvider rejects the unknown client; the route maps it to an error
-    // page and records an auth_user failure datapoint.
-    expect(res.status).toBe(500)
-    expect(writtenEvents(metricsSpy)).toContain('auth_user')
+    expect(res.status).toBe(400)
+    expect(await res.text()).toContain('Invalid client_id')
+    expect(writtenEvents(metricsSpy)).not.toContain('auth_user')
+  })
+
+  it('returns a local retryable error when CIMD metadata resolution fails', async () => {
+    vi.spyOn(
+      (env as Env & { OAUTH_PROVIDER: OAuthHelpers }).OAUTH_PROVIDER,
+      'lookupClient'
+    ).mockRejectedValueOnce(
+      new CimdFetchError('https://client.example.com/oauth.json', new Error('upstream timeout'))
+    )
+
+    const response = await exports.default.fetch(
+      new Request(
+        authorizeUrl({
+          response_type: 'code',
+          client_id: 'https://client.example.com/oauth.json',
+          redirect_uri: REDIRECT_URI,
+          code_challenge: DOWNSTREAM_CODE_CHALLENGE,
+          code_challenge_method: 'S256'
+        })
+      )
+    )
+
+    expect(response.status).toBe(503)
+    expect(response.headers.get('retry-after')).toBe('30')
+    expect(await response.text()).toContain('Client metadata is temporarily unavailable')
+    expect(writtenEvents(metricsSpy)).not.toContain('auth_user')
+  })
+
+  it('returns a local invalid_request page when client_id is missing', async () => {
+    const response = await exports.default.fetch(
+      new Request(
+        authorizeUrl({
+          response_type: 'code',
+          redirect_uri: REDIRECT_URI,
+          code_challenge: DOWNSTREAM_CODE_CHALLENGE,
+          code_challenge_method: 'S256'
+        })
+      )
+    )
+
+    expect(response.status).toBe(400)
+    expect(await response.text()).toContain('Missing client_id')
+    expect(writtenEvents(metricsSpy)).not.toContain('auth_user')
   })
 })
 


### PR DESCRIPTION
## Summary

Use the tagged authorization-request errors from cloudflare/workers-oauth-provider#283 to return OAuth-spec-correct failures without matching provider error strings or duplicating security validation.

Developer experience:

```ts
try {
  request = await env.OAUTH_PROVIDER.parseAuthRequest(raw)
} catch (error) {
  if (!(error instanceof AuthorizationError)) throw error
  if (!error.redirectUri) return renderLocalError(error)
  return redirectOAuthError(error)
}
```

`redirectUri` presence is the provider's safety proof:

- missing/unknown client and invalid redirect URI → local HTTP 400 page, never redirect
- malformed resource, unsupported response type, and PKCE failures after exact redirect validation → OAuth 302 error redirect
- redirected errors include original `state` and RFC 9207 `iss`
- tagged `CimdFetchError` → local HTTP 503 `temporarily_unavailable`, `Retry-After: 30`
- unexpected lookup/KV/provider failures remain 500

HTML OAuth errors preserve structured headers such as `Retry-After`.

## Provider dependency

This PR uses released `@cloudflare/workers-oauth-provider@0.10.0` from cloudflare/workers-oauth-provider#283.

## Production evidence

Workers Observability showed `/authorize` 500s from bare authorization requests and dynamic client lookup failures. This maps those expected failures correctly while keeping redirect safety inside the provider.

## Standards

- OAuth 2.1 §4.1.2.1: invalid client/redirect failures must not redirect
- OAuth authorization errors: `invalid_request`, `unauthorized_client`, `unsupported_response_type`
- RFC 9207 issuer identification on error redirects
- MCP 2026-07-28 authorization response validation

## Validation

- `npm ci`
- `npm run check`: 19 files, 252 tests
- provider PR: 8 files, 798 tests; build passed
- staging version: `194408e8-c9c2-4eab-a385-100f9872b533`
- live matrix:
  - missing client: local 400
  - unknown client: local 400
  - invalid redirect: local 400, no redirect
  - missing PKCE: 302 `invalid_request` with state + iss
  - unsupported response type: 302 `unsupported_response_type` with state + iss
  - malformed resource: 302 `invalid_request` with state + iss

