### PR TITLE
Use canonical ChatGPT submission schema

### DIFF
--- a/chatgpt-app-submission.json
+++ b/chatgpt-app-submission.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://developers.openai.com/apps-sdk/schemas/chatgpt-app-submission.v1.json",
+  "$schema": "https://developers.openai.com/plugins/schemas/chatgpt-app-submission.v1.json",
   "schema_version": 1,
   "app_info": {
     "display_name": "Cloudflare",


### PR DESCRIPTION
## Summary

Update `chatgpt-app-submission.json` to use the canonical schema URL currently published by OpenAI.

The URL generated by the installed OpenAI Developers skill redirects to the current schema, but the schema requires its canonical `$id` as the exact `$schema` value.

## Validation

- fetched the schema from OpenAI Developers
- validated the complete submission with `jsonschema.Draft202012Validator`
- `npx oxfmt --check chatgpt-app-submission.json`
- `git diff --check`
