### PR TITLE
test: cover explicit account selection in execute

### DIFF
--- a/tests/executor.test.ts
+++ b/tests/executor.test.ts
@@ -178,6 +178,23 @@ describe('execute: no account resolved (multi-account user token)', () => {
     expect(toolText(result)).toContain('"success": true')
   })
 
+  it('binds accountId from an explicit account_id for multi-account users', async () => {
+    mockMultiAccountUser()
+    server.use(
+      http.get(`${API_BASE}/accounts/${ACCOUNT_ID}/workers/scripts`, () =>
+        HttpResponse.json({ success: true, result: [] })
+      )
+    )
+
+    const result = await callTool(API_TOKEN, 'execute', {
+      account_id: ACCOUNT_ID,
+      code: `async () => cloudflare.request({ method: "GET", path: \`/accounts/\${accountId}/workers/scripts\` })`
+    })
+
+    expect(result.result?.isError).toBeFalsy()
+    expect(toolText(result)).toContain('"success": true')
+  })
+
   it('fails fast with a clear message when code reads the unset accountId', async () => {
     mockMultiAccountUser()
     const result = await callTool(API_TOKEN, 'execute', {


### PR DESCRIPTION
AI-generated contribution. I am the human operator responsible for follow-up with maintainers. Please feel free to close this PR or request any changes.

## Summary

Add regression coverage for the multi-account `execute` path when callers pass an explicit `account_id` and sandbox code reads `accountId`.

## Problem

Issue #204 reports that the hosted MCP accepted `account_id` but then raised `ReferenceError: accountId is not defined` inside the execute sandbox. Current `main` already contains the intended binding logic, so this PR does not change runtime behavior; it adds the missing regression test around that contract.

## Change

Extend `tests/executor.test.ts` with a multi-account case that:
- supplies `account_id` to `execute`;
- reads `accountId` inside sandboxed code;
- reaches the expected account-scoped Cloudflare API path; and
- asserts the tool call succeeds.

## Why this approach

This is the smallest change that directly covers the failure mode described in #204 without touching auth, token handling, deployment configuration, dependencies, or the execute implementation itself.

## Verification

- `npm test -- tests/executor.test.ts`: 15/15 tests passed locally.
- `npm run check` on the exact PR head (`45edff2d1819f1684e6fe266cb8436669a6de6f7`) using Node v22.23.2 on the win4060 WSL2 worker: passed.
- Full suite result: 21/21 test files passed, 282/282 tests passed.
- Format check, lint, and TypeScript typecheck all passed as part of `npm run check`.

## Risk / compatibility

Test-only change. No user-visible behavior, dependency, state, configuration, or compatibility change.

## Related

Related: #204.

## AI / agent disclosure

This contribution was prepared and tested with assistance from an autonomous AI coding agent operated by Keeltrace.
